### PR TITLE
Security upgrade

### DIFF
--- a/src/data/cache_management.ts
+++ b/src/data/cache_management.ts
@@ -47,6 +47,14 @@ export async function cacheData(data: GlobalData) {
     return;
 }
 
+export async function storeSecurity(security: { [workspace: string]: true }) {
+    await saveFileAsync(path.join(cacheFolder, "security.json"), JSON.stringify(security));
+}
+
+export async function readSecurity(): Promise<{ [workspace: string]: true }> {
+    return JSON.parse((await readFileAsync(path.join(cacheFolder, "security.json"))).toString());
+}
+
 //#region Helper Functions
 const readFileAsync = promisify(fs.readFile);
 async function readJSON<T>(filePath: string): Promise<T> {

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -5,11 +5,11 @@ import { NamespaceData } from "./datapack_resources";
  * Data which is useful no matter where the function is.
  */
 export interface GlobalData {
+    blocks: BlocksPropertyInfo;
     commands: CommandTree;
     resources: NamespaceData;
-    meta_info: { version: string };
-    blocks: BlocksPropertyInfo;
     items: string[];
+    meta_info: { version: string };
 }
 
 //#region Command Tree

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -79,6 +79,12 @@ interface McFunctionSettings {
          */
         snapshots: boolean;
     }
+    /**
+     * Custom parsers to be used
+     */
+    parsers: {
+        [name: string]: string;
+    }
 }
 /**
  * Log a message to the console.

--- a/src/parse/parsers/get_parser.ts
+++ b/src/parse/parsers/get_parser.ts
@@ -1,8 +1,9 @@
+import * as path from "path";
 import { CommandNode } from "../../data/types";
 import { Parser } from "../../types";
 
 /**
- * Incomplete
+ * Incomplete:
  * https://github.com/Levertion/mcfunction-langserver/issues/11
  */
 const implementedParsers: { [id: string]: string } = {
@@ -42,8 +43,11 @@ along with: '${JSON.stringify(error)}'.`);
 }
 
 function getArgParserPath(id: string): string {
-    if (implementedParsers.hasOwnProperty(id)) {
-        return implementedParsers[id];
+    if (!!global.mcLangSettings && // Protection for tests when settings are undefined
+        !!global.mcLangSettings.parsers && global.mcLangSettings.parsers.hasOwnProperty(id)) {
+        return global.mcLangSettings.parsers[id];
+    } else if (implementedParsers.hasOwnProperty(id)) {
+        return path.join(__dirname, implementedParsers[id]);
     } else {
         mcLangLog(`Argument with parser id ${id} has no associated parser.
 Please consider reporting this at https://github.com/Levertion/mcfunction-language-server/issues`);

--- a/src/security.ts
+++ b/src/security.ts
@@ -1,0 +1,16 @@
+function requiresSecurityCheck(change: McFunctionSettings): string[] | false {
+    const results: string[] = [];
+    if (!!change.data) {
+        if (!!change.data.customJar) {
+            results.push("Custom Jar Path (mcfunction.data.customJar)");
+        }
+        if (!!change.data.javaPath) {
+            results.push("Custom java path (mcfunction.data.javaPath)");
+        }
+    }
+    if (results.length === 0) {
+        return false;
+    } else {
+        return results;
+    }
+}

--- a/src/security.ts
+++ b/src/security.ts
@@ -8,6 +8,12 @@ function requiresSecurityCheck(change: McFunctionSettings): string[] | false {
             results.push("Custom java path (mcfunction.data.javaPath)");
         }
     }
+    if (!!change.parsers) {
+        const names = Object.keys(change.parsers);
+        if (names.length > 0) {
+            results.push(`Custom parsers for '${names.join()}'`);
+        }
+    }
     if (results.length === 0) {
         return false;
     } else {

--- a/src/test/completions.test.ts
+++ b/src/test/completions.test.ts
@@ -4,8 +4,12 @@ import { ComputeCompletions } from "../completions";
 import { DataManager } from "../data/manager";
 import { GlobalData } from "../data/types";
 import { CommandLine } from "../types";
+import { setup_test } from "./logging_setup";
 
 describe("ComputeCompletions()", () => {
+    before(() => {
+        setup_test();
+    });
     it("should replace an internal node", () => {
         const result = ComputeCompletions(0, {
             datapack_root: "",

--- a/src/test/logging_setup.ts
+++ b/src/test/logging_setup.ts
@@ -1,11 +1,16 @@
-const logger = (message: string) => {
-    // tslint:disable-next-line:no-console
-    console.log(message);
-};
+import * as path from "path";
 
-global.mcLangLog = Object.assign(logger,
-    { internal: (message: string) => logger(`[McFunctionInternal] ${message}`) });
+export function setup_test() {
+    global.mcLangSettings = {
+        parsers: {
+            "langserver:dummy1": path.join(__dirname, "parse", "parsers", "tests", "dummy1_parser"),
+        },
+    } as any as McFunctionSettings;
+    const logger = (message: string) => {
+        // tslint:disable-next-line:no-console
+        console.log(message);
+    };
 
-export function trick() {
-    // Does nothing but tricks the compiler into actually including this file.
+    global.mcLangLog = Object.assign(logger,
+        { internal: (message: string) => logger(`[McFunctionInternal] ${message}`) });
 }

--- a/src/test/parse/index.test.ts
+++ b/src/test/parse/index.test.ts
@@ -2,9 +2,13 @@ import * as assert from "assert";
 import { GlobalData } from "../../data/types";
 import { parseCommand } from "../../parse/index";
 import { ParsedInfo } from "../../types";
+import { setup_test } from "../logging_setup";
 import { assertErrors } from "./parsers/utils/parser_test_utils";
 
 describe("parseCommand()", () => {
+    before(() => {
+        setup_test();
+    });
     describe("No command", () => {
         it("should return nothing when the string is empty", () => {
             assert.deepEqual(parseCommand("", {} as any as GlobalData),

--- a/src/test/parse/parsers/get_parser.test.ts
+++ b/src/test/parse/parsers/get_parser.test.ts
@@ -1,15 +1,26 @@
 import * as assert from "assert";
+import * as path from "path";
+import * as stringParser from "../../../parse/parsers/brigadier/string";
 import { getParser } from "../../../parse/parsers/get_parser";
 import * as literal from "../../../parse/parsers/literal";
-import * as dummy1 from "../../../parse/parsers/tests/dummy1";
+import * as dummy1 from "./tests/dummy1_parser";
 
 describe("getParser()", () => {
     it("should give the literal parser for a literal node", () => {
         const parser = getParser({ type: "literal" });
         assert.equal(parser, literal);
     });
-    it("should give the correct parser for an argument node", () => {
+    it("should give the correct parser for a custom parser", () => {
+        global.mcLangSettings = {
+            parsers: {
+                "langserver:dummy1": path.join(__dirname, "tests", "dummy1_parser"),
+            },
+        } as any as McFunctionSettings;
         const parser = getParser({ type: "argument", parser: "langserver:dummy1" });
         assert.equal(parser, dummy1);
+    });
+    it("should give the correct parser for a builtin parser", () => {
+        const parser = getParser({ type: "argument", parser: "brigadier:string" });
+        assert.equal(parser, stringParser);
     });
 });

--- a/src/test/parse/parsers/tests/dummy1.test.ts
+++ b/src/test/parse/parsers/tests/dummy1.test.ts
@@ -1,8 +1,8 @@
 import * as assert from "assert";
 import { CompletionItemKind } from "vscode-languageserver/lib/main";
 import { StringReader } from "../../../../brigadier_components/string_reader";
-import * as dummyparser from "../../../../parse/parsers/tests/dummy1";
 import { ParserInfo } from "../../../../types";
+import * as dummyparser from "./dummy1_parser";
 
 describe("dummyParser1", () => {
     describe("parse", () => {

--- a/src/test/parse/parsers/tests/dummy1_parser.ts
+++ b/src/test/parse/parsers/tests/dummy1_parser.ts
@@ -1,5 +1,5 @@
 import { CompletionItemKind } from "vscode-languageserver/lib/main";
-import { Parser } from "../../../types";
+import { Parser } from "../../../../types";
 
 /**
  * Used for testing.


### PR DESCRIPTION
Add a way to confirm that the user wants to use the potentially insecure settings.

This prevents our extension being a security problem by someone opening a folder with malicious settings.
Also includes the changes described in https://github.com/Levertion/mcfunction-langserver/pull/10#issuecomment-378598920, allowing settings to define custom parsers.
cc @MrYurihi for #10 

There are no longer test parsers includes in `implementedParsers`