### PR TITLE
Block parsers

### DIFF
--- a/src/brigadier_components/string_reader.ts
+++ b/src/brigadier_components/string_reader.ts
@@ -1,3 +1,4 @@
+import { CompletionItemKind } from "vscode-languageserver";
 import { ReturnHelper } from "../misc_functions";
 import { typed_keys } from "../misc_functions/third_party/typed_keys";
 import { CE, ReturnedInfo, Suggestion } from "../types";
@@ -204,7 +205,8 @@ export class StringReader {
      */
     public readOption<T extends string>(
         options: T[],
-        addError: boolean = true
+        addError: boolean = true,
+        completion?: CompletionItemKind
     ): ReturnedInfo<T, CE, string | false> {
         const start = this.cursor;
         const helper = new ReturnHelper();
@@ -221,6 +223,7 @@ export class StringReader {
                     ...options
                         .filter(v => v.startsWith(remaining))
                         .map<Suggestion>(v => ({
+                            kind: completion,
                             start,
                             text: `${QUOTE}${v}${QUOTE}`
                         }))
@@ -239,6 +242,7 @@ export class StringReader {
                 ...options
                     .filter(v => v.startsWith(result.data))
                     .map<Suggestion>(v => ({
+                        kind: completion,
                         start,
                         text:
                             quoted || v.includes('"') || v.includes("\\")

--- a/src/brigadier_components/string_reader.ts
+++ b/src/brigadier_components/string_reader.ts
@@ -303,6 +303,7 @@ export class StringReader {
             } else if (c === ESCAPE) {
                 escaped = true;
             } else if (c === QUOTE) {
+                this.skip();
                 return helper.succeed(result);
             } else {
                 result += c;

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -7,3 +7,6 @@ export const NAMESPACE = ":";
 export const DATAFOLDER = "data";
 export const SLASH = "/";
 export const MCMETAFILE = "pack.mcmeta";
+
+// Blocks
+export const TAG_START = "#";

--- a/src/data/datapack_resources.ts
+++ b/src/data/datapack_resources.ts
@@ -10,9 +10,11 @@ import {
 } from "../misc_functions/promisified_fs";
 import { typed_keys } from "../misc_functions/third_party/typed_keys";
 import { ReturnSuccess } from "../types";
+import { mapPacksInfo } from "./extractor/mapfunctions";
 import {
     Datapack,
     DataPackID,
+    GlobalData,
     McmetaFile,
     MinecraftResource,
     PacksInfo,
@@ -63,14 +65,6 @@ export async function getNamespaceResources(
                             .slice(0, -realExtension.length)
                             .replace(path.sep, SLASH)
                     };
-                    if (!!resourceInfo.readJson) {
-                        const jsonData = await readJSON(file);
-                        if (helper.merge(jsonData)) {
-                            // @ts-ignore The resources are only officially allowed to be MinecraftResources.
-                            // However, they are cast to DataResources at a later time if applicable.
-                            newResource.data = jsonData.data;
-                        }
-                    }
                     nameSpaceContents.push(newResource);
                 })
             );
@@ -83,7 +77,8 @@ export async function getNamespaceResources(
 
 async function buildDataPack(
     packFolder: string,
-    id: DataPackID
+    id: DataPackID,
+    packName: string
 ): Promise<ReturnSuccess<Datapack>> {
     const helper = new ReturnHelper();
     const dataFolder = path.join(packFolder, DATAFOLDER);
@@ -91,7 +86,7 @@ async function buildDataPack(
         readJSON<McmetaFile>(path.join(packFolder, MCMETAFILE)),
         getPackResources(dataFolder, id)
     ]);
-    const result: Datapack = { id, data: packResources.data };
+    const result: Datapack = { id, data: packResources.data, name: packName };
     helper.merge(packResources);
     if (helper.merge(mcmeta)) {
         result.mcmeta = mcmeta.data;
@@ -122,7 +117,8 @@ async function getPackResources(
 }
 
 export async function getPacksInfo(
-    location: string
+    location: string,
+    globalData: GlobalData
 ): Promise<ReturnSuccess<PacksInfo>> {
     const packNames = await subDirectories(location);
     const helper = new ReturnHelper();
@@ -131,14 +127,15 @@ export async function getPacksInfo(
     const promises: Array<Promise<void>> = packs.map(
         async ([packID, packName]) => {
             const loc = path.join(location, packName);
-            const packData = await buildDataPack(loc, packID);
+            const packData = await buildDataPack(loc, packID, packName);
             helper.merge(packData);
             result.packs[packID] = packData.data;
             result.packnamesmap[packName] = packID;
         }
     );
     await Promise.all(promises);
-    return helper.succeed(result);
+    const otherResult = await mapPacksInfo(result, globalData);
+    return helper.mergeChain(otherResult).succeed(otherResult.data);
 }
 
 async function walkDir(currentPath: string): Promise<string[]> {

--- a/src/data/extractor/mapfunctions.ts
+++ b/src/data/extractor/mapfunctions.ts
@@ -1,0 +1,63 @@
+import { resourceTypes, ReturnHelper } from "../../misc_functions";
+import { typed_keys } from "../../misc_functions/third_party/typed_keys";
+
+import { join } from "path";
+import { ReturnSuccess } from "../../types";
+import { GlobalData, PacksInfo, Resources } from "../types";
+
+export async function runMapFunctions(
+    resources: Resources,
+    globalData: GlobalData,
+    packRoot: string,
+    localData?: PacksInfo
+): Promise<ReturnSuccess<Resources>> {
+    const result: Resources = {};
+    const helper = new ReturnHelper();
+    const promises: Array<Promise<void>> = [];
+    for (const type of typed_keys(resources)) {
+        type resourcesType = NonNullable<Resources[typeof type]>;
+        const val = (result[type] = [] as resourcesType);
+        const data = resources[type] as resourcesType;
+        // tslint:disable-next-line:no-unbound-method We control this function, so we know it won't use the this keyword.
+        const mapFunction = resourceTypes[type].mapFunction;
+        if (mapFunction) {
+            promises.push(
+                ...data.map(async v => {
+                    const res = await mapFunction(
+                        v,
+                        packRoot,
+                        globalData,
+                        localData
+                    );
+                    helper.merge(res);
+                    val.push(res.data);
+                })
+            );
+        } else {
+            val.push(...data);
+        }
+    }
+    await Promise.all(promises);
+    return helper.succeed(result);
+}
+
+export async function mapPacksInfo(
+    packsInfo: PacksInfo,
+    global: GlobalData
+): Promise<ReturnSuccess<PacksInfo>> {
+    const helper = new ReturnHelper();
+    const result: PacksInfo = { ...packsInfo, packs: {} };
+    const promises = typed_keys(packsInfo.packs).map(async packID => {
+        const element = packsInfo.packs[packID];
+        const subresult = await runMapFunctions(
+            element.data,
+            global,
+            join(packsInfo.location, element.name),
+            packsInfo
+        );
+        helper.merge(subresult);
+        result.packs[packID] = { ...element, data: subresult.data };
+    });
+    await Promise.all(promises);
+    return helper.succeed(result);
+}

--- a/src/data/manager.ts
+++ b/src/data/manager.ts
@@ -3,7 +3,7 @@ import {
     FileChangeType
 } from "vscode-languageserver";
 
-import { extname } from "path";
+import { extname, join } from "path";
 import { MCMETAFILE } from "../consts";
 import {
     getKindAndNamespace,
@@ -23,6 +23,7 @@ import {
     Datapack,
     DataPackID,
     GlobalData,
+    LocalData,
     McmetaFile,
     MinecraftResource,
     PacksInfo
@@ -61,14 +62,14 @@ export class DataManager {
 
     public getPackFolderData(
         folder: PackLocationSegments | undefined
-    ): PacksInfo | undefined {
+    ): LocalData | undefined {
         if (
             !!folder &&
             this.packDataComplete.hasOwnProperty(folder.packsFolder)
         ) {
             const info = this.packDataComplete[folder.packsFolder];
 
-            return info;
+            return { ...info, current: info.packnamesmap[folder.pack] };
         }
         return undefined;
     }
@@ -79,102 +80,126 @@ export class DataManager {
         const helper = new ReturnHelper(false);
         const firsts = new Set<string>();
         const promises = event.changes.map(async change => {
-            const parsedPath = parseDataPath(change.uri);
-            if (parsedPath) {
-                interface InlineData {
-                    data: PacksInfo;
-                    pack: Datapack;
-                    packID: DataPackID;
-                }
-                const getData = async (): Promise<InlineData> => {
-                    const first = await this.readPackFolderData(
-                        parsedPath.packsFolder
-                    );
-                    if (first) {
-                        firsts.add(parsedPath.packsFolder);
+            try {
+                const parsedPath = parseDataPath(change.uri);
+                if (parsedPath) {
+                    interface InlineData {
+                        data: PacksInfo;
+                        pack: Datapack;
+                        packID: DataPackID;
                     }
-                    const data = this.getPackFolderData(parsedPath);
-                    if (!data) {
-                        throw new Error(
-                            "Could not load data from datapacks folder"
+                    const getData = async (): Promise<InlineData> => {
+                        const first = await this.readPackFolderData(
+                            parsedPath.packsFolder
                         );
-                    }
-                    const packID = data.packnamesmap[parsedPath.pack];
-                    const pack = data.packs[packID];
-                    return { data, pack, packID };
-                };
+                        if (first) {
+                            firsts.add(parsedPath.packsFolder);
+                        }
+                        const data = this.getPackFolderData(parsedPath);
+                        if (!data) {
+                            throw new Error(
+                                "Could not load data from datapacks folder"
+                            );
+                        }
+                        const packID = data.packnamesmap[parsedPath.pack];
+                        const pack = data.packs[packID];
+                        return { data, pack, packID };
+                    };
 
-                if (parsedPath.rest === MCMETAFILE) {
-                    const { pack } = await getData();
-                    if (!firsts.has(parsedPath.packsFolder)) {
-                        const res = await readJSON<McmetaFile>(change.uri);
-                        pack.mcmeta = helper.merge(res) ? res.data : undefined;
-                    }
-                } else {
-                    const namespace = getKindAndNamespace(parsedPath.rest);
-                    if (namespace) {
-                        const { pack, packID } = await getData();
+                    if (parsedPath.rest === MCMETAFILE) {
+                        const { pack } = await getData();
                         if (!firsts.has(parsedPath.packsFolder)) {
-                            const shouldUpdateContents =
-                                change.type === FileChangeType.Changed &&
-                                resourceTypes[namespace.kind].readJson;
-                            let contents = pack.data[namespace.kind];
-                            if (
-                                (change.type === FileChangeType.Deleted ||
-                                    shouldUpdateContents) &&
-                                !!contents
-                            ) {
-                                for (let i = 0; i < contents.length; i++) {
-                                    const element = contents[i];
-                                    if (
-                                        namespacesEqual(
-                                            element,
-                                            namespace.location
-                                        )
-                                    ) {
-                                        contents.splice(i, 1);
-                                        break;
-                                    }
-                                }
-                            }
-                            if (
-                                change.type === FileChangeType.Created ||
-                                shouldUpdateContents
-                            ) {
-                                if (!contents) {
-                                    contents = pack.data[namespace.kind] = [];
-                                }
-                                const newResource: MinecraftResource = {
-                                    ...namespace.location,
-                                    pack: packID
-                                };
-                                const actual = extname(change.uri);
-                                const expected =
-                                    resourceTypes[namespace.kind].extension;
-                                if (actual === expected) {
-                                    if (
-                                        resourceTypes[namespace.kind].readJson
-                                    ) {
-                                        const data = await readJSON(change.uri);
-                                        if (helper.merge(data)) {
-                                            // @ts-ignore
-                                            newResource.data = data.data;
+                            const res = await readJSON<McmetaFile>(change.uri);
+                            pack.mcmeta = helper.merge(res)
+                                ? res.data
+                                : undefined;
+                        }
+                    } else {
+                        const namespace = getKindAndNamespace(parsedPath.rest);
+                        if (namespace) {
+                            const { pack, packID, data } = await getData();
+                            if (!firsts.has(parsedPath.packsFolder)) {
+                                const shouldUpdateContents =
+                                    change.type === FileChangeType.Changed &&
+                                    resourceTypes[namespace.kind].mapFunction;
+                                let contents = pack.data[namespace.kind];
+                                if (
+                                    (change.type === FileChangeType.Deleted ||
+                                        shouldUpdateContents) &&
+                                    !!contents
+                                ) {
+                                    for (let i = 0; i < contents.length; i++) {
+                                        const element = contents[i];
+                                        if (
+                                            namespacesEqual(
+                                                element,
+                                                namespace.location
+                                            )
+                                        ) {
+                                            contents.splice(i, 1);
+                                            break;
                                         }
                                     }
-                                    contents.push(newResource);
-                                } else {
-                                    helper.addMisc(
-                                        createExtensionFileError(
-                                            change.uri,
-                                            expected,
-                                            actual
-                                        )
-                                    );
+                                }
+                                if (
+                                    change.type === FileChangeType.Created ||
+                                    shouldUpdateContents
+                                ) {
+                                    if (!contents) {
+                                        contents = pack.data[
+                                            namespace.kind
+                                        ] = [];
+                                    }
+                                    const newResource: MinecraftResource = {
+                                        ...namespace.location,
+                                        pack: packID
+                                    };
+                                    const actual = extname(change.uri);
+                                    const expected =
+                                        resourceTypes[namespace.kind].extension;
+                                    if (actual === expected) {
+                                        const mapFunction =
+                                            // tslint:disable-next-line:no-unbound-method We control this function, so we know it won't use the this keyword.
+                                            resourceTypes[namespace.kind]
+                                                .mapFunction;
+                                        if (mapFunction) {
+                                            const result = await mapFunction(
+                                                newResource,
+                                                join(
+                                                    parsedPath.packsFolder,
+                                                    parsedPath.pack
+                                                ),
+                                                this.globalData,
+                                                data
+                                            );
+                                            if (helper.merge(result)) {
+                                                contents.push(result.data);
+                                            }
+                                        } else {
+                                            contents.push(newResource);
+                                        }
+                                    } else {
+                                        helper.addMisc(
+                                            createExtensionFileError(
+                                                change.uri,
+                                                expected,
+                                                actual
+                                            )
+                                        );
+                                    }
                                 }
                             }
                         }
                     }
                 }
+            } catch (error) {
+                mcLangLog(
+                    `Change ${JSON.stringify(
+                        change
+                    )} could not be completed, due to '${JSON.stringify(
+                        error
+                    )}'`
+                );
             }
         });
         await Promise.all(promises);
@@ -187,8 +212,10 @@ export class DataManager {
             version = this.globalData.meta_info.version;
         }
         try {
+            const helper = new ReturnHelper();
             const data = await collectGlobalData(version);
-            this.globalDataInternal = data;
+            helper.merge(data);
+            this.globalDataInternal = data.data;
             return true;
         } catch (error) {
             return error.toString();
@@ -217,7 +244,10 @@ export class DataManager {
     ): Promise<ReturnedInfo<void>> {
         const helper = new ReturnHelper();
         if (!this.packDataPromises.hasOwnProperty(folder)) {
-            this.packDataPromises[folder] = getPacksInfo(folder);
+            this.packDataPromises[folder] = getPacksInfo(
+                folder,
+                this.globalData
+            );
             const result = await this.packDataPromises[folder];
             this.packDataComplete[folder] = result.data;
             helper.merge(result);

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -79,6 +79,7 @@ export interface Datapack {
     data: Resources;
     id: DataPackID;
     mcmeta?: McmetaFile;
+    name: string;
 }
 
 export interface McmetaFile {
@@ -98,6 +99,10 @@ export interface LocalData extends PacksInfo {
 }
 
 export interface MinecraftResource extends NamespacedName {
+    /**
+     * Namespace will be defined for a MinecraftResource
+     */
+    namespace: string;
     /**
      * The datapack this resource is related to.
      * If undefined, must be the vanilla datapack

--- a/src/misc_functions/datapack_folder.ts
+++ b/src/misc_functions/datapack_folder.ts
@@ -10,7 +10,7 @@ import {
     Tag
 } from "../data/types";
 import { ReturnSuccess } from "../types";
-import { getNamespaces, getResourcesSplit } from "./group_resources";
+import { getMatching, getResourcesSplit } from "./group_resources";
 import { convertToNamespace } from "./namespace";
 import { readJSON } from "./promisified_fs";
 import { ReturnHelper } from "./returnhelper";
@@ -95,7 +95,7 @@ export const resourceTypes: { [T in keyof Resources]-?: ResourceInfo<T> } = {
                 packroot,
                 "function_tags",
                 getResourcesSplit("function_tags", globalData, packsInfo),
-                s => getNamespaces(functions, convertToNamespace(s)).length > 0
+                s => getMatching(functions, convertToNamespace(s)).length > 0
             );
         },
         path: ["tags", "functions"]
@@ -195,7 +195,7 @@ async function readTag(
                 !!tag.data.values,
                 filePath,
                 "InvalidTagNoValues",
-                "tag does not have a values tag"
+                `tag does not have a values key: ${JSON.stringify(tag.data)}`
             )
         ) {
             if (
@@ -203,7 +203,9 @@ async function readTag(
                     Array.isArray(tag.data.values),
                     filePath,
                     "InvalidTagValuesNotArray",
-                    "tag values is not an array"
+                    `tag values is not an array: ${JSON.stringify(
+                        tag.data.values
+                    )}`
                 )
             ) {
                 if (
@@ -212,7 +214,9 @@ async function readTag(
                         tag.data.values.every(v => typeof v === "string"),
                         filePath,
                         "InvalidTagValuesNotString",
-                        "tag values contains a non string value"
+                        `tag values contains a non string value: ${JSON.stringify(
+                            tag.data.values
+                        )}`
                     )
                 ) {
                     const seen = new Set<string>();
@@ -224,7 +228,7 @@ async function readTag(
                         }
                         seen.add(value);
                         if (value.startsWith(TAG_START)) {
-                            const result = getNamespaces(
+                            const result = getMatching(
                                 options,
                                 convertToNamespace(value)
                             );

--- a/src/misc_functions/datapack_folder.ts
+++ b/src/misc_functions/datapack_folder.ts
@@ -1,6 +1,19 @@
 import * as defaultPath from "path";
-import { DATAFOLDER, SLASH } from "../consts";
-import { NamespacedName, Resources } from "../data/types";
+import { DATAFOLDER, SLASH, TAG_START } from "../consts";
+import {
+    DataResource,
+    GlobalData,
+    MinecraftResource,
+    NamespacedName,
+    PacksInfo,
+    Resources,
+    Tag
+} from "../data/types";
+import { ReturnSuccess } from "../types";
+import { getNamespaces, getResourcesSplit } from "./group_resources";
+import { convertToNamespace } from "./namespace";
+import { readJSON } from "./promisified_fs";
+import { ReturnHelper } from "./returnhelper";
 import { typed_keys } from "./third_party/typed_keys";
 
 /** A minimal path module for use in this file */
@@ -44,22 +57,62 @@ export function parseDataPath(
     return undefined;
 }
 
-interface ResourceInfo<U = string> {
+interface ResourceInfo<U extends keyof Resources> {
     extension: string;
     path: [U] | string[]; // Custom tuple improves autocomplete mostly.
-    readJson?: boolean;
+    mapFunction?(
+        value: NonNullable<Resources[U]> extends Array<infer T> ? T : never,
+        packroot: string,
+        globalData: GlobalData,
+        packsInfo?: PacksInfo
+    ): Promise<ReturnSuccess<typeof value>>;
 }
 
 export const resourceTypes: { [T in keyof Resources]-?: ResourceInfo<T> } = {
     advancements: { extension: ".json", path: ["advancements"] },
     block_tags: {
         extension: ".json",
-        path: ["tags", "blocks"],
-        readJson: true
+        mapFunction: async (v, packroot, globalData, packsInfo) =>
+            readTag(
+                v,
+                packroot,
+                "block_tags",
+                getResourcesSplit("block_tags", globalData, packsInfo),
+                s => globalData.blocks.hasOwnProperty(s)
+            ),
+        path: ["tags", "blocks"]
     },
-    function_tags: { extension: ".json", path: ["tags", "functions"] },
+    function_tags: {
+        extension: ".json",
+        mapFunction: async (v, packroot, globalData, packsInfo) => {
+            const functions = getResourcesSplit(
+                "functions",
+                globalData,
+                packsInfo
+            );
+            return readTag(
+                v,
+                packroot,
+                "function_tags",
+                getResourcesSplit("function_tags", globalData, packsInfo),
+                s => getNamespaces(functions, convertToNamespace(s)).length > 0
+            );
+        },
+        path: ["tags", "functions"]
+    },
     functions: { extension: ".mcfunction", path: ["functions"] },
-    item_tags: { extension: ".json", path: ["tags", "items"] },
+    item_tags: {
+        extension: ".json",
+        mapFunction: async (v, packroot, globalData, packsInfo) =>
+            readTag(
+                v,
+                packroot,
+                "item_tags",
+                getResourcesSplit("item_tags", globalData, packsInfo),
+                s => globalData.items.indexOf(s) !== -1
+            ),
+        path: ["tags", "items"]
+    },
     loot_tables: { extension: ".json", path: ["loot_tables"] },
     recipes: { extension: ".json", path: ["recipes"] },
     structures: { extension: ".nbt", path: ["structures"] }
@@ -67,7 +120,7 @@ export const resourceTypes: { [T in keyof Resources]-?: ResourceInfo<T> } = {
 
 interface KindNamespace {
     kind: keyof Resources;
-    location: NamespacedName;
+    location: NamespacedName & { namespace: string };
 }
 
 export function getKindAndNamespace(
@@ -107,4 +160,104 @@ export function getKindAndNamespace(
         }
     }
     return undefined;
+}
+
+export function getPath(
+    resource: MinecraftResource,
+    packroot: string,
+    kind: keyof Resources,
+    path: PathModule = defaultPath
+): string {
+    return path.join(
+        packroot,
+        DATAFOLDER,
+        resource.namespace,
+        ...resourceTypes[kind].path,
+        resource.path
+            .replace(SLASH, path.sep)
+            .concat(resourceTypes[kind].extension)
+    );
+}
+
+async function readTag(
+    resource: MinecraftResource,
+    packRoot: string,
+    type: keyof Resources,
+    options: MinecraftResource[],
+    isKnown: (value: string) => boolean
+): Promise<ReturnSuccess<DataResource<Tag> | MinecraftResource>> {
+    const helper = new ReturnHelper();
+    const filePath = getPath(resource, packRoot, type);
+    const tag = await readJSON<Tag>(filePath);
+    if (helper.merge(tag)) {
+        if (
+            helper.addFileErrorIfFalse(
+                !!tag.data.values,
+                filePath,
+                "InvalidTagNoValues",
+                "tag does not have a values tag"
+            )
+        ) {
+            if (
+                helper.addFileErrorIfFalse(
+                    Array.isArray(tag.data.values),
+                    filePath,
+                    "InvalidTagValuesNotArray",
+                    "tag values is not an array"
+                )
+            ) {
+                if (
+                    helper.addFileErrorIfFalse(
+                        // tslint:disable-next-line:strict-type-predicates
+                        tag.data.values.every(v => typeof v === "string"),
+                        filePath,
+                        "InvalidTagValuesNotString",
+                        "tag values contains a non string value"
+                    )
+                ) {
+                    const seen = new Set<string>();
+                    const duplicates = new Set<string>();
+                    const unknowns = new Set<string>();
+                    for (const value of tag.data.values) {
+                        if (seen.has(value)) {
+                            duplicates.add(value);
+                        }
+                        seen.add(value);
+                        if (value.startsWith(TAG_START)) {
+                            const result = getNamespaces(
+                                options,
+                                convertToNamespace(value)
+                            );
+                            if (result.length === 0) {
+                                unknowns.add(value);
+                            }
+                        } else if (!isKnown(value)) {
+                            unknowns.add(value);
+                        }
+                    }
+                    helper.addFileErrorIfFalse(
+                        duplicates.size === 0,
+                        filePath,
+                        "InvalidTagValuesDuplicates",
+                        `Tag contains duplicate values: "${[...duplicates].join(
+                            '", "'
+                        )}"`
+                    );
+                    helper.addFileErrorIfFalse(
+                        unknowns.size === 0,
+                        filePath,
+                        "InvalidTagValuesUnknown",
+                        `Tag contains unknown values: "${[...unknowns].join(
+                            '", "'
+                        )}"`
+                    );
+                    return helper.succeed({
+                        ...resource,
+                        data: tag.data
+                    });
+                }
+            }
+        }
+    }
+    return helper.succeed(resource);
 }

--- a/src/misc_functions/datapack_folder.ts
+++ b/src/misc_functions/datapack_folder.ts
@@ -179,6 +179,25 @@ export function getPath(
     );
 }
 
+export function buildPath(
+    resource: MinecraftResource,
+    packs: PacksInfo,
+    kind: keyof Resources,
+    path: PathModule = defaultPath
+): string | undefined {
+    if (resource.pack) {
+        const pack = packs.packs[resource.pack];
+        return getPath(
+            resource,
+            path.join(packs.location, pack.name),
+            kind,
+            path
+        );
+    } else {
+        return undefined;
+    }
+}
+
 async function readTag(
     resource: MinecraftResource,
     packRoot: string,

--- a/src/misc_functions/group_resources.ts
+++ b/src/misc_functions/group_resources.ts
@@ -42,7 +42,7 @@ export function getResourcesSplit<
     return results as T[];
 }
 
-export function getNamespaces<T extends NamespacedName>(
+export function getMatching<T extends NamespacedName>(
     resources: T[],
     value: T
 ): T[] {

--- a/src/misc_functions/group_resources.ts
+++ b/src/misc_functions/group_resources.ts
@@ -1,19 +1,35 @@
-import { MinecraftResource, Resources } from "../data/types";
+import {
+    GlobalData,
+    MinecraftResource,
+    NamespacedName,
+    PacksInfo,
+    Resources
+} from "../data/types";
 import { CommmandData } from "../types";
+import { namespacesEqual } from "./namespace";
 
 export function getResourcesofType<
     T extends MinecraftResource = MinecraftResource
 >(resources: CommmandData, type: keyof Resources): T[] {
+    return getResourcesSplit<T>(
+        type,
+        resources.globalData,
+        resources.localData
+    );
+}
+
+export function getResourcesSplit<
+    T extends MinecraftResource = MinecraftResource
+>(type: keyof Resources, globalData: GlobalData, packsInfo?: PacksInfo): T[] {
     const results: MinecraftResource[] = [];
-    const globalResources = resources.globalData.resources[type];
+    const globalResources = globalData.resources[type];
     if (!!globalResources) {
         results.push(...globalResources);
     }
-    if (!!resources.localData) {
-        const localData = resources.localData;
-        for (const packId in localData.packs) {
-            if (localData.packs.hasOwnProperty(packId)) {
-                const pack = localData.packs[packId];
+    if (packsInfo) {
+        for (const packId in packsInfo.packs) {
+            if (packsInfo.packs.hasOwnProperty(packId)) {
+                const pack = packsInfo.packs[packId];
                 if (pack.data.hasOwnProperty(type)) {
                     const data = pack.data[type];
                     if (!!data) {
@@ -24,4 +40,17 @@ export function getResourcesofType<
         }
     }
     return results as T[];
+}
+
+export function getNamespaces<T extends NamespacedName>(
+    resources: T[],
+    value: T
+): T[] {
+    const results: T[] = [];
+    for (const resource of resources) {
+        if (namespacesEqual(resource, value)) {
+            results.push(resource);
+        }
+    }
+    return results;
 }

--- a/src/misc_functions/parsing/namespace.ts
+++ b/src/misc_functions/parsing/namespace.ts
@@ -8,7 +8,7 @@ import { CommandErrorBuilder } from "../../brigadier_components/errors";
 import { StringReader } from "../../brigadier_components/string_reader";
 import { DEFAULT_NAMESPACE } from "../../consts";
 import { NamespacedName } from "../../data/types";
-import { CE, ReturnedInfo } from "../../types";
+import { CE, ReturnedInfo, Suggestion } from "../../types";
 
 const NAMESPACEEXCEPTIONS = {
     invalid_id: new CommandErrorBuilder(
@@ -43,6 +43,33 @@ export function namespaceStart(
             base.namespace === test.namespace && base.path.startsWith(test.path)
         );
     }
+}
+
+export function namespaceSuggestions(
+    options: NamespacedName[],
+    value: NamespacedName,
+    start: number
+): Suggestion[] {
+    const result: Suggestion[] = [];
+    for (const option of options) {
+        if (namespaceStart(option, value)) {
+            result.push({ text: stringifyNamespace(option), start });
+        }
+    }
+    return result;
+}
+
+export function namespaceSuggestionString(
+    options: string[],
+    value: NamespacedName,
+    start: number
+): Suggestion[] {
+    return namespaceSuggestions(
+        // tslint:disable-next-line:no-unnecessary-callback-wrapper this is a false positive - see https://github.com/palantir/tslint/issues/2430
+        options.map(v => convertToNamespace(v)),
+        value,
+        start
+    );
 }
 
 export function parseNamespace(

--- a/src/misc_functions/parsing/namespace.ts
+++ b/src/misc_functions/parsing/namespace.ts
@@ -1,3 +1,4 @@
+import { CompletionItemKind } from "vscode-languageserver";
 import {
     convertToNamespace,
     namespacesEqual,
@@ -107,7 +108,8 @@ interface OptionResult<T> {
 
 export function parseNamespaceOption<T extends NamespacedName>(
     reader: StringReader,
-    options: T[]
+    options: T[],
+    completionKind?: CompletionItemKind
 ): ReturnedInfo<OptionResult<T>, CE, NamespacedName | undefined> {
     const helper = new ReturnHelper();
     const start = reader.cursor;
@@ -119,10 +121,11 @@ export function parseNamespaceOption<T extends NamespacedName>(
                 results.push(val);
             }
             if (!reader.canRead() && namespaceStart(val, namespace.data)) {
-                helper.addSuggestions({
+                helper.addSuggestion(
                     start,
-                    text: stringifyNamespace(val)
-                });
+                    stringifyNamespace(val),
+                    completionKind
+                );
             }
         }
         if (results.length > 0) {

--- a/src/misc_functions/parsing/nmsp_tag.ts
+++ b/src/misc_functions/parsing/nmsp_tag.ts
@@ -31,6 +31,15 @@ interface TagParseResult {
     values?: MinecraftResource[];
 }
 
+/**
+ * Parse a namespace or tag.
+ * Returned:
+ *  - values are the resources which are the exact matches
+ *  - resolved are the lowest level tag members
+ *  - parsed is the literal tag. If parsed exists, but not resolved/values, then it was a non-tag
+ *  - if not successful, if data undefined then parsing failed.
+ *  - if data is a value, then a tag parsed but was unknown
+ */
 export function parseNamespaceOrTag(
     reader: StringReader,
     info: ParserInfo,

--- a/src/misc_functions/parsing/nmsp_tag.ts
+++ b/src/misc_functions/parsing/nmsp_tag.ts
@@ -40,9 +40,9 @@ export function parseNamespaceOrTag(
     taghandling: keyof Resources | CommandErrorBuilder
 ): ReturnedInfo<TagParseResult, CE, NamespacedName | undefined> {
     const helper = new ReturnHelper(info);
+    const start = reader.cursor;
     if (reader.peek() === TAG_START) {
         reader.skip();
-        const tagStart = reader.cursor;
         if (typeof taghandling === "string") {
             const tags: Array<DataResource<Tag>> = getResourcesofType(
                 info.data,
@@ -65,7 +65,7 @@ export function parseNamespaceOrTag(
             }
         } else {
             readNamespaceText(reader);
-            return helper.fail(taghandling.create(tagStart, reader.cursor));
+            return helper.fail(taghandling.create(start, reader.cursor));
         }
     } else {
         if (!reader.canRead() && typeof taghandling === "string") {

--- a/src/misc_functions/parsing/nmsp_tag.ts
+++ b/src/misc_functions/parsing/nmsp_tag.ts
@@ -1,3 +1,4 @@
+import { CompletionItemKind } from "vscode-languageserver";
 import { CommandErrorBuilder } from "../../brigadier_components/errors";
 import { StringReader } from "../../brigadier_components/string_reader";
 import { TAG_START } from "../../consts";
@@ -48,7 +49,11 @@ export function parseNamespaceOrTag(
                 info.data,
                 taghandling
             );
-            const parsed = parseNamespaceOption(reader, tags);
+            const parsed = parseNamespaceOption(
+                reader,
+                tags,
+                CompletionItemKind.Folder
+            );
             if (helper.merge(parsed)) {
                 const values = parsed.data.values;
                 const resolved: NamespacedName[] = [];
@@ -69,7 +74,11 @@ export function parseNamespaceOrTag(
         }
     } else {
         if (!reader.canRead() && typeof taghandling === "string") {
-            helper.addSuggestion(reader.cursor, TAG_START);
+            helper.addSuggestion(
+                reader.cursor,
+                TAG_START,
+                CompletionItemKind.Operator
+            );
         }
         const parsed = parseNamespace(reader);
         if (helper.merge(parsed)) {

--- a/src/misc_functions/parsing/nmsp_tag.ts
+++ b/src/misc_functions/parsing/nmsp_tag.ts
@@ -1,0 +1,103 @@
+import { CommandErrorBuilder } from "../../brigadier_components/errors";
+import { StringReader } from "../../brigadier_components/string_reader";
+import { TAG_START } from "../../consts";
+import {
+    DataResource,
+    MinecraftResource,
+    NamespacedName,
+    Resources,
+    Tag
+} from "../../data/types";
+import { CE, ParserInfo, ReturnedInfo } from "../../types";
+import { getResourcesofType } from "../group_resources";
+import { convertToNamespace, namespacesEqual } from "../namespace";
+import { ReturnHelper } from "../returnhelper";
+import {
+    parseNamespace,
+    parseNamespaceOption,
+    readNamespaceText
+} from "./namespace";
+
+const EXCEPTIONS = {
+    no_tags: new CommandErrorBuilder(
+        "argument.tags.notallowed",
+        "Block tags are not allowed here"
+    )
+};
+
+interface TagParseResult {
+    parsed: NamespacedName;
+    resolved?: NamespacedName[];
+    values?: MinecraftResource[];
+}
+
+export function parseNamespaceOrTag(
+    reader: StringReader,
+    info: ParserInfo,
+    tagType?: keyof Resources
+): ReturnedInfo<TagParseResult, CE, NamespacedName | undefined> {
+    const helper = new ReturnHelper(info);
+    if (reader.peek() === TAG_START) {
+        reader.skip();
+        const tagStart = reader.cursor;
+        if (tagType) {
+            const tags: Array<DataResource<Tag>> = getResourcesofType(
+                info.data,
+                tagType
+            );
+            const parsed = parseNamespaceOption(reader, tags);
+            if (helper.merge(parsed)) {
+                const values = parsed.data.values;
+                const resolved: NamespacedName[] = [];
+                for (const value of values) {
+                    resolved.push(...getLowestForTag(value, tags));
+                }
+                return helper.succeed<TagParseResult>({
+                    parsed: parsed.data.literal,
+                    resolved,
+                    values
+                });
+            } else {
+                return helper.failWithData(parsed.data);
+            }
+        } else {
+            readNamespaceText(reader);
+            return helper.fail(
+                EXCEPTIONS.no_tags.create(tagStart, reader.cursor)
+            );
+        }
+    } else {
+        if (!reader.canRead() && tagType) {
+            helper.addSuggestion(reader.cursor, TAG_START);
+        }
+        const parsed = parseNamespace(reader);
+        if (helper.merge(parsed)) {
+            return helper.succeed({ parsed: parsed.data });
+        } else {
+            return helper.fail();
+        }
+    }
+}
+
+function getLowestForTag(
+    tag: DataResource<Tag>,
+    options: Array<DataResource<Tag>>
+): NamespacedName[] {
+    if (!tag.data) {
+        return [];
+    }
+    const results: NamespacedName[] = [];
+    for (const tagMember of tag.data.values) {
+        if (tagMember[0] === TAG_START) {
+            const namespace = convertToNamespace(tagMember.substring(1));
+            for (const option of options) {
+                if (namespacesEqual(namespace, option)) {
+                    results.push(...getLowestForTag(option, options));
+                }
+            }
+        } else {
+            results.push(convertToNamespace(tagMember));
+        }
+    }
+    return results;
+}

--- a/src/parsers/get_parser.ts
+++ b/src/parsers/get_parser.ts
@@ -4,13 +4,15 @@ import { Parser } from "../types";
 
 /**
  * Incomplete:
- * https://github.com/Levertion/mcfunction-langserver/issues/11
+ * https://github.com/Levertion/mcfunction-langserver/projects/1
  */
 const implementedParsers: { [id: string]: string } = {
     "brigadier:bool": "./brigadier/bool",
     "brigadier:float": "./brigadier/float",
     "brigadier:integer": "./brigadier/integer",
-    "brigadier:string": "./brigadier/string"
+    "brigadier:string": "./brigadier/string",
+    "minecraft:block_predicate": "./minecraft/block/predicate",
+    "minecraft:block_state": "./minecraft/block/state"
 };
 
 export function getParser(node: CommandNode): Parser | undefined {

--- a/src/parsers/minecraft/block/block_predicate.ts
+++ b/src/parsers/minecraft/block/block_predicate.ts
@@ -1,0 +1,8 @@
+import { Parser } from "../../../types";
+import { parseBlockArgument } from "./shared";
+
+const parser: Parser = {
+    parse: (reader, info) => parseBlockArgument(reader, info, false)
+};
+
+export = parser;

--- a/src/parsers/minecraft/block/block_state.ts
+++ b/src/parsers/minecraft/block/block_state.ts
@@ -1,0 +1,8 @@
+import { Parser } from "../../../types";
+import { parseBlockArgument } from "./shared";
+
+const parser: Parser = {
+    parse: (reader, info) => parseBlockArgument(reader, info, false)
+};
+
+export = parser;

--- a/src/parsers/minecraft/block/shared.ts
+++ b/src/parsers/minecraft/block/shared.ts
@@ -1,4 +1,4 @@
-import { DiagnosticSeverity } from "vscode-languageserver";
+import { CompletionItemKind, DiagnosticSeverity } from "vscode-languageserver";
 
 import { CommandErrorBuilder } from "../../../brigadier_components/errors";
 import { StringReader } from "../../../brigadier_components/string_reader";
@@ -209,7 +209,11 @@ function parseProperties(
         while (reader.canRead() && reader.peek() !== "]") {
             reader.skipWhitespace();
             const propStart = reader.cursor;
-            const propParse = reader.readOption(props, false);
+            const propParse = reader.readOption(
+                props,
+                false,
+                CompletionItemKind.Property
+            );
             const propKey = propParse.data;
             const propSuccessful = helper.merge(propParse);
             if (propKey === false) {
@@ -251,7 +255,11 @@ function parseProperties(
             reader.skip();
             reader.skipWhitespace();
             const valueStart = reader.cursor;
-            const valueParse = reader.readOption(options[propKey] || [], false);
+            const valueParse = reader.readOption(
+                options[propKey] || [],
+                false,
+                CompletionItemKind.EnumMember
+            );
             const valueSuccessful = helper.merge(valueParse);
             const value = valueParse.data;
             if (value === false) {
@@ -286,6 +294,7 @@ function parseProperties(
         if (!reader.canRead()) {
             helper.addSuggestions(
                 ...props.map<Suggestion>(prop => ({
+                    kind: CompletionItemKind.Property,
                     start: reader.cursor,
                     text: prop
                 }))

--- a/src/parsers/minecraft/block/shared.ts
+++ b/src/parsers/minecraft/block/shared.ts
@@ -1,0 +1,302 @@
+import { DiagnosticSeverity } from "vscode-languageserver";
+
+import { CommandErrorBuilder } from "../../../brigadier_components/errors";
+import { StringReader } from "../../../brigadier_components/string_reader";
+import {
+    BlocksPropertyInfo,
+    NamespacedName,
+    SingleBlockPropertyInfo
+} from "../../../data/types";
+import { ReturnHelper, stringifyNamespace } from "../../../misc_functions";
+import {
+    buildTagActions,
+    parseNamespaceOrTag
+} from "../../../misc_functions/parsing/nmsp_tag";
+import { ParserInfo, ReturnedInfo } from "../../../types";
+
+interface PropertyExceptions {
+    duplicate: CommandErrorBuilder;
+    invalid: CommandErrorBuilder;
+    novalue: CommandErrorBuilder;
+    unknown: CommandErrorBuilder;
+}
+
+const exceptions = {
+    block_properties: {
+        duplicate: new CommandErrorBuilder(
+            "argument.block.property.duplicate",
+            "Property '%s' can only be set once for block %s"
+        ),
+        invalid: new CommandErrorBuilder(
+            "argument.block.property.invalid",
+            "Block %s does not accept '%s' for %s property"
+        ),
+        novalue: new CommandErrorBuilder(
+            "argument.block.property.novalue",
+            "Expected value for property '%s' on block %s"
+        ),
+        unknown: new CommandErrorBuilder(
+            "argument.block.property.unknown",
+            "Block %s does not have property '%s'"
+        )
+    },
+    invalid_block: new CommandErrorBuilder(
+        "argument.block.id.invalid",
+        "Unknown block type '%s'"
+    ),
+    no_tags: new CommandErrorBuilder(
+        "argument.block.tag.disallowed",
+        "Tags aren't allowed here, only actual blocks"
+    ),
+    tag_properties: {
+        duplicate: new CommandErrorBuilder(
+            "argument.block_tag.property.duplicate",
+            "Property '%s' can only be set once for block tag %s"
+        ),
+        invalid: new CommandErrorBuilder(
+            "argument.block_tag.property.invalid",
+            "Block tag %s does not accept '%s' for %s property"
+        ),
+        novalue: new CommandErrorBuilder(
+            "argument.block_tag.property.novalue",
+            "Expected value for property '%s' on block tag %s"
+        ),
+        unknown: new CommandErrorBuilder(
+            "argument.block_tag.property.unknown",
+            "Block tag %s does not have property '%s'"
+        )
+    },
+    unknown_properties: {
+        duplicate: new CommandErrorBuilder(
+            "argument.unknown_block_tag.property.duplicate",
+            "Property '%s' can only be set once for unknown block tag %s"
+        ),
+        invalid: new CommandErrorBuilder(
+            "argument.unknown_block_tag.property.invalid",
+            "Unknown block tag %s might not accept '%s' for %s property",
+            DiagnosticSeverity.Warning
+        ),
+        novalue: new CommandErrorBuilder(
+            "argument.unknown_block_tag.property.novalue",
+            "Expected value for property '%s' on unknown block tag %s"
+        ),
+        unknown: new CommandErrorBuilder(
+            "argument.unknown_block_tag.property.unknown",
+            "Unknown block tag %s might not have property '%s'",
+            DiagnosticSeverity.Warning
+        )
+    },
+
+    unclosed_props: new CommandErrorBuilder(
+        "argument.block.property.unclosed",
+        "Expected closing ] for block state properties"
+    ),
+
+    unknown_tag: new CommandErrorBuilder(
+        "arguments.block.tag.unknown",
+        "Unknown block tag '%s'"
+    )
+};
+
+export function parseBlockArgument(
+    reader: StringReader,
+    info: ParserInfo,
+    tags: boolean
+): ReturnedInfo<undefined> {
+    const helper = new ReturnHelper(info);
+    const start = reader.cursor;
+    const tagHandling = tags ? "block_tags" : exceptions.no_tags;
+    const parsed = parseNamespaceOrTag(reader, info, tagHandling);
+    let stringifiedName: string | undefined;
+    if (helper.merge(parsed)) {
+        const parsedResult = parsed.data;
+        if (parsedResult.resolved && parsedResult.values) {
+            stringifiedName = `#${stringifyNamespace(parsedResult.parsed)}`;
+            helper.merge(
+                buildTagActions(
+                    parsedResult.values,
+                    start + 1,
+                    reader.cursor,
+                    info.data.localData
+                )
+            );
+            const props = constructProperties(
+                parsedResult.resolved,
+                info.data.globalData.blocks
+            );
+            const propsResult = parseProperties(
+                reader,
+                props || {},
+                exceptions.tag_properties,
+                stringifiedName
+            );
+            if (!helper.merge(propsResult)) {
+                return helper.fail();
+            }
+        } else {
+            stringifiedName = stringifyNamespace(parsed.data.parsed);
+            const props = info.data.globalData.blocks[stringifiedName];
+            if (!props) {
+                helper.addErrors(
+                    exceptions.invalid_block.create(start, reader.cursor)
+                );
+            }
+            const result = parseProperties(
+                reader,
+                props || {},
+                exceptions.block_properties,
+                stringifiedName
+            );
+            if (!helper.merge(result)) {
+                return helper.fail();
+            }
+        }
+    } else {
+        if (parsed.data) {
+            helper.addErrors(
+                exceptions.unknown_tag.create(
+                    start,
+                    reader.cursor,
+                    stringifyNamespace(parsed.data)
+                )
+            );
+            stringifiedName = `#${stringifyNamespace(parsed.data)}`;
+            const propsResult = parseProperties(
+                reader,
+                {},
+                exceptions.unknown_properties,
+                stringifiedName
+            );
+            if (!helper.merge(propsResult)) {
+                return helper.fail();
+            }
+        } else {
+            // Parsing of the namespace failed
+            return helper.fail();
+        }
+    }
+    return helper.succeed();
+}
+
+// Ugly call signature. Need to see how upstream handles tag properties.
+// At the moment, it is very broken
+function parseProperties(
+    reader: StringReader,
+    options: SingleBlockPropertyInfo,
+    errors: PropertyExceptions,
+    name: string
+): ReturnedInfo<Map<string, string>> {
+    const helper = new ReturnHelper();
+    const result = new Map<string, string>();
+    if (reader.peek() === "[") {
+        const start = reader.cursor;
+        reader.skip();
+        const props = Object.keys(options);
+        reader.skipWhitespace();
+        while (reader.canRead() && reader.peek() !== "]") {
+            reader.skipWhitespace();
+            const propStart = reader.cursor;
+            const propParse = reader.readOption(props, false);
+            const propKey = propParse.data;
+            const propSuccessful = helper.merge(propParse);
+            if (propKey === false) {
+                // Strange order allows better type checker reasoning
+                // Parsing failed
+                return helper.fail();
+            }
+            if (!propSuccessful) {
+                helper.addErrors(
+                    errors.unknown.create(
+                        propStart,
+                        reader.cursor,
+                        name,
+                        propKey
+                    )
+                );
+            }
+            if (result.has(propKey)) {
+                helper.addErrors(
+                    errors.duplicate.create(
+                        propStart,
+                        reader.cursor,
+                        propKey,
+                        name
+                    )
+                );
+            }
+            reader.skipWhitespace();
+            if (!reader.canRead() || reader.peek() !== "=") {
+                return helper.fail(
+                    errors.novalue.create(
+                        propStart,
+                        reader.cursor,
+                        propKey,
+                        name
+                    )
+                );
+            }
+            reader.skip();
+            reader.skipWhitespace();
+            const valueStart = reader.cursor;
+            const valueParse = reader.readOption(options[propKey] || [], false);
+            const valueSuccessful = helper.merge(valueParse);
+            const value = valueParse.data;
+            if (value === false) {
+                return helper.fail();
+            }
+            if (propSuccessful && !valueSuccessful) {
+                helper.addErrors(
+                    errors.invalid.create(
+                        valueStart,
+                        reader.cursor,
+                        name,
+                        value,
+                        propKey
+                    )
+                );
+            }
+            result.set(propKey, value);
+            reader.skipWhitespace();
+            if (reader.canRead()) {
+                if (reader.peek() === ",") {
+                    reader.skip();
+                    continue;
+                }
+                if (reader.peek() === "]") {
+                    break;
+                }
+            }
+            return helper.fail(
+                exceptions.unclosed_props.create(start, reader.cursor)
+            );
+        }
+        if (!reader.canRead()) {
+            return helper.fail(
+                exceptions.unclosed_props.create(start, reader.cursor)
+            );
+        }
+        reader.expect("]"); // Sanity check
+    }
+    return helper.succeed(result);
+}
+
+function constructProperties(
+    options: NamespacedName[],
+    blocks: BlocksPropertyInfo
+): SingleBlockPropertyInfo {
+    const result: SingleBlockPropertyInfo = {};
+    for (const blockName of options) {
+        const stringified = stringifyNamespace(blockName);
+        const block = blocks[stringified];
+        if (block) {
+            for (const prop in block) {
+                if (block.hasOwnProperty(prop)) {
+                    result[stringified] = Array.from(
+                        new Set((result[stringified] || []).concat(block[prop]))
+                    );
+                }
+            }
+        }
+    }
+    return result;
+}

--- a/src/test/blanks.ts
+++ b/src/test/blanks.ts
@@ -1,3 +1,4 @@
+import { GlobalData } from "../data/types";
 import { PackLocationSegments } from "../misc_functions";
 import { CommmandData } from "../types";
 import { ReturnAssertionInfo, TestParserInfo } from "./assertions";
@@ -20,4 +21,12 @@ export const blankproperties: TestParserInfo = {
     data: {} as CommmandData,
     node_properties: {},
     path: ["test"]
+};
+
+export const emptyGlobal: GlobalData = {
+    blocks: {},
+    commands: { type: "root" },
+    items: [],
+    meta_info: { version: "" },
+    resources: {}
 };

--- a/src/test/brigadier_components/string_reader.test.ts
+++ b/src/test/brigadier_components/string_reader.test.ts
@@ -514,7 +514,46 @@ describe("string-reader", () => {
         });
     });
     describe("readOption", () => {
-        // TODO
+        it("should work properly", () => {
+            const reader = new StringReader("test");
+            const result = reader.readOption(["test", "other"]);
+            if (
+                returnAssert(result, {
+                    succeeds: true,
+                    suggestions: ["test"]
+                })
+            ) {
+                assert.equal(result.data, "test");
+            }
+        });
+        it("should give an error with an unknown value", () => {
+            const reader = new StringReader("test");
+            const result = reader.readOption(["nottest", "other"]);
+            if (
+                returnAssert(result, {
+                    errors: [
+                        {
+                            code: "parsing.expected.option",
+                            range: { start: 0, end: 4 }
+                        }
+                    ],
+                    succeeds: false
+                })
+            ) {
+                assert.equal(result.data, "test");
+            }
+        });
+        it("should not give an error when addError is false and there is an unknown value", () => {
+            const reader = new StringReader("test");
+            const result = reader.readOption(["nottest", "other"], false);
+            if (
+                returnAssert(result, {
+                    succeeds: false
+                })
+            ) {
+                assert.equal(result.data, "test");
+            }
+        });
     });
     describe("readWhileFunction()", () => {
         it("should not read the first character if the callback fails on it", () => {

--- a/src/test/brigadier_components/string_reader.test.ts
+++ b/src/test/brigadier_components/string_reader.test.ts
@@ -348,6 +348,7 @@ describe("string-reader", () => {
             const result = reader.readQuotedString();
             if (returnAssert(result, succeeds)) {
                 assert.strictEqual(result.data, "");
+                assert.strictEqual(reader.cursor, 4);
             }
         });
         it("should throw an error if there is no opening quote", () => {
@@ -368,6 +369,7 @@ describe("string-reader", () => {
             const result = reader.readQuotedString();
             if (returnAssert(result, succeeds)) {
                 assert.strictEqual(result.data, "hello");
+                assert.strictEqual(reader.cursor, 7);
             }
         });
         it("should return an empty string when there is an empty quoted string", () => {
@@ -375,6 +377,7 @@ describe("string-reader", () => {
             const result = reader.readQuotedString();
             if (returnAssert(result, succeeds)) {
                 assert.strictEqual(result.data, "");
+                assert.strictEqual(reader.cursor, 2);
             }
         });
         it("should allow escaped quotes", () => {
@@ -382,6 +385,7 @@ describe("string-reader", () => {
             const result = reader.readQuotedString();
             if (returnAssert(result, succeeds)) {
                 assert.strictEqual(result.data, 'quote"here');
+                assert.strictEqual(reader.cursor, 13);
             }
         });
         it("should allow escaped backslashes", () => {
@@ -389,6 +393,7 @@ describe("string-reader", () => {
             const result = reader.readQuotedString();
             if (returnAssert(result, succeeds)) {
                 assert.strictEqual(result.data, "backslash\\here");
+                assert.strictEqual(reader.cursor, 17);
             }
         });
         it("should not allow surplus escapes", () => {

--- a/src/test/data/datapack_resource.test.ts
+++ b/src/test/data/datapack_resource.test.ts
@@ -4,7 +4,7 @@ import { getPacksInfo } from "../../data/datapack_resources";
 import { Datapack, MinecraftResource, PacksInfo } from "../../data/types";
 import { typed_keys } from "../../misc_functions/third_party/typed_keys";
 import { assertMembers, assertNamespaces, returnAssert } from "../assertions";
-import { succeeds } from "../blanks";
+import { emptyGlobal } from "../blanks";
 
 // Tests are run from within the lib folder, but data is in the root
 const rootFolder = path.join(__dirname, "..", "..", "..", "test_data");
@@ -16,36 +16,34 @@ describe("Datapack Resource Testing", () => {
                 data: {
                     function_tags: [{ namespace: "minecraft", path: "tick" }],
                     functions: [
-                        {
-                            namespace: "test_namespace",
-                            path: "function"
-                        }
+                        { namespace: "test_namespace", path: "function" }
                     ]
                 },
                 id: 0,
                 mcmeta: {
                     pack: { pack_format: 3, description: "test datapack" }
-                }
+                },
+                name: "ExampleDatapack"
             },
             ExampleDatapack2: {
                 data: {
                     functions: [
-                        {
-                            namespace: "test_namespace",
-                            path: "function"
-                        }
+                        { namespace: "test_namespace", path: "function" }
                     ]
                 },
                 id: 1,
                 mcmeta: {
                     pack: { pack_format: 3, description: "test datapack 2" }
-                }
+                },
+                name: "ExampleDatapack2"
             }
         };
         const result = await getPacksInfo(
-            path.join(rootFolder, "test_world", "datapacks")
+            path.join(rootFolder, "test_world", "datapacks"),
+            emptyGlobal
         );
-        returnAssert(result, succeeds);
+        returnAssert(result, { succeeds: true, numMisc: 4 });
+        assert(result.misc.every(v => v.kind === "ClearError"));
         assertPacksInfo(result.data, datapacks, expected);
     });
 });

--- a/src/test/data/datapack_resource.test.ts
+++ b/src/test/data/datapack_resource.test.ts
@@ -42,7 +42,7 @@ describe("Datapack Resource Testing", () => {
             path.join(rootFolder, "test_world", "datapacks"),
             emptyGlobal
         );
-        returnAssert(result, { succeeds: true, numMisc: 4 });
+        returnAssert(result, { succeeds: true, numMisc: 5 });
         assert(result.misc.every(v => v.kind === "ClearError"));
         assertPacksInfo(result.data, datapacks, expected);
     });

--- a/src/test/misc_functions/datapack_folder.test.ts
+++ b/src/test/misc_functions/datapack_folder.test.ts
@@ -2,10 +2,12 @@ import * as assert from "assert";
 import * as path from "path";
 import {
     getKindAndNamespace,
+    getPath,
     parseDataPath
 } from "../../misc_functions/datapack_folder";
+import { unwrap } from "../assertions";
 
-describe("Calculate Data Folder (Misc)", () => {
+describe("parseDataPath() (Misc)", () => {
     it("should parse a path with a valid datapack (posix)", () => {
         assert.deepStrictEqual(
             parseDataPath("/home/datapacks/pack/folder/file.ext", path.posix),
@@ -94,7 +96,7 @@ describe("Calculate Data Folder (Misc)", () => {
     });
 });
 
-describe("getKindAndNamespace (Misc)", () => {
+describe("getKindAndNamespace() (Misc)", () => {
     it("should get the correct kind and namespace (posix)", () => {
         assert.deepStrictEqual(
             getKindAndNamespace(
@@ -234,6 +236,32 @@ describe("getKindAndNamespace (Misc)", () => {
         assert.strictEqual(
             getKindAndNamespace("data\\namespace\\functions\\path.notfunction"),
             undefined
+        );
+    });
+});
+
+describe("getPath() (Misc)", () => {
+    function testGetPath(s: string, pthModule: typeof path.posix): void {
+        const parsed = unwrap(parseDataPath(s, pthModule));
+        const kindNspc = unwrap(getKindAndNamespace(parsed.rest, pthModule));
+        const result = getPath(
+            kindNspc.location,
+            pthModule.join(parsed.packsFolder, parsed.pack),
+            kindNspc.kind,
+            pthModule
+        );
+        assert.strictEqual(s, result);
+    }
+    it("should give a correct path (posix)", () => {
+        testGetPath(
+            "/home/datapacks/pack/data/namespace/functions/path.mcfunction",
+            path.posix
+        );
+    });
+    it("should give a correct path (win32)", () => {
+        testGetPath(
+            "C:\\Users\\username\\datapacks\\pack\\data\\namespace\\functions\\path.mcfunction",
+            path.win32
         );
     });
 });

--- a/src/test/misc_functions/group_resources.test.ts
+++ b/src/test/misc_functions/group_resources.test.ts
@@ -15,6 +15,7 @@ const dummyData: CommmandData = {
         }
     } as any,
     localData: {
+        current: 0,
         location: "",
         packnamesmap: { testpack: 0, pack2: 1 },
         packs: {
@@ -38,7 +39,8 @@ const dummyData: CommmandData = {
                         }
                     ]
                 },
-                id: 0
+                id: 0,
+                name: "testpack"
             },
             1: {
                 data: {
@@ -46,7 +48,8 @@ const dummyData: CommmandData = {
                         { namespace: "secondpath", path: "path", pack: 1 }
                     ]
                 },
-                id: 1
+                id: 1,
+                name: "pack2"
             }
         }
     }

--- a/src/test/misc_functions/parsing/nmsp_tag.test.ts
+++ b/src/test/misc_functions/parsing/nmsp_tag.test.ts
@@ -1,3 +1,142 @@
+import * as assert from "assert";
+
+import { StringReader } from "../../../brigadier_components/string_reader";
+import { namespacesEqual } from "../../../misc_functions";
+import { parseNamespaceOrTag } from "../../../misc_functions/parsing/nmsp_tag";
+import { ParserInfo } from "../../../types";
+import { assertNamespaces, returnAssert } from "../../assertions";
+import { blankproperties, succeeds } from "../../blanks";
+
+const data: ParserInfo = {
+    ...blankproperties,
+    data: {
+        globalData: {
+            resources: {
+                block_tags: [
+                    {
+                        data: { values: ["#outside:tock", "minecraft:stone"] },
+                        namespace: "minecraft",
+                        path: "tick"
+                    },
+                    {
+                        data: { values: ["minecraft:white_wool"] },
+                        namespace: "outside",
+                        path: "tock"
+                    }
+                ]
+            }
+        },
+        localData: {
+            packs: {
+                0: {
+                    data: {
+                        block_tags: [
+                            {
+                                data: { values: ["minecraft:red_wool"] },
+                                namespace: "outside",
+                                path: "tock"
+                            }
+                        ]
+                    },
+                    name: "test1"
+                }
+            }
+        }
+    } as any,
+
+    suggesting: false
+};
+
 describe("parseNamespaceOrTag", () => {
-    // TODO
+    it("should allow a normal namespace to be parsed", () => {
+        const reader = new StringReader("minecraft:stone");
+        const result = parseNamespaceOrTag(reader, {
+            ...blankproperties,
+            suggesting: false
+        });
+        if (returnAssert(result, succeeds)) {
+            assert(
+                namespacesEqual(result.data.parsed, {
+                    namespace: "minecraft",
+                    path: "stone"
+                })
+            );
+        }
+    });
+    it("should give an error with an invalid namespace", () => {
+        const reader = new StringReader("minecraft:fail:surplus");
+        const result = parseNamespaceOrTag(reader, {
+            ...blankproperties,
+            suggesting: false
+        });
+        if (
+            returnAssert(result, {
+                errors: [
+                    {
+                        code: "argument.id.invalid",
+                        range: { start: 14, end: 15 }
+                    }
+                ],
+                succeeds: false
+            })
+        ) {
+            assert.equal(result.data, undefined);
+        }
+    });
+    it("should give an error when there is a tag but tags are not supported", () => {
+        const reader = new StringReader("#minecraft:tag");
+        const result = parseNamespaceOrTag(
+            reader,
+            {
+                ...blankproperties,
+                suggesting: false
+            },
+            undefined
+        );
+        if (
+            returnAssert(result, {
+                errors: [
+                    {
+                        code: "argument.tags.notallowed",
+                        range: { start: 1, end: 14 }
+                    }
+                ],
+                succeeds: false
+            })
+        ) {
+            assert.equal(result.data, undefined);
+        }
+    });
+    it("should fail when there is a tag which is unknown", () => {
+        const reader = new StringReader("#minecraft:tag");
+        const result = parseNamespaceOrTag(reader, data, "block_tags");
+        if (
+            returnAssert(result, {
+                succeeds: false
+            })
+        ) {
+            assert.deepStrictEqual(result.data, {
+                namespace: "minecraft",
+                path: "tag"
+            });
+        }
+    });
+    it("should resolve the tag successfully", () => {
+        const reader = new StringReader("#minecraft:tick");
+        const result = parseNamespaceOrTag(reader, data, "block_tags");
+        if (returnAssert(result, { succeeds: true })) {
+            assert.deepStrictEqual(result.data.parsed, {
+                namespace: "minecraft",
+                path: "tick"
+            });
+            assertNamespaces(
+                [
+                    { namespace: "minecraft", path: "stone" },
+                    { namespace: "minecraft", path: "white_wool" },
+                    { namespace: "minecraft", path: "red_wool" }
+                ],
+                result.data.resolved
+            );
+        }
+    });
 });

--- a/src/test/misc_functions/parsing/nmsp_tag.test.ts
+++ b/src/test/misc_functions/parsing/nmsp_tag.test.ts
@@ -1,0 +1,3 @@
+describe("parseNamespaceOrTag", () => {
+    // TODO
+});

--- a/src/test/misc_functions/parsing/nmsp_tag.test.ts
+++ b/src/test/misc_functions/parsing/nmsp_tag.test.ts
@@ -1,5 +1,6 @@
 import * as assert from "assert";
 
+import { CommandErrorBuilder } from "../../../brigadier_components/errors";
 import { StringReader } from "../../../brigadier_components/string_reader";
 import { namespacesEqual } from "../../../misc_functions";
 import { parseNamespaceOrTag } from "../../../misc_functions/parsing/nmsp_tag";
@@ -47,13 +48,16 @@ const data: ParserInfo = {
     suggesting: false
 };
 
+const errorBuilder = new CommandErrorBuilder("test", "test");
+
 describe("parseNamespaceOrTag", () => {
     it("should allow a normal namespace to be parsed", () => {
         const reader = new StringReader("minecraft:stone");
-        const result = parseNamespaceOrTag(reader, {
-            ...blankproperties,
-            suggesting: false
-        });
+        const result = parseNamespaceOrTag(
+            reader,
+            { ...blankproperties, suggesting: false },
+            errorBuilder
+        );
         if (returnAssert(result, succeeds)) {
             assert(
                 namespacesEqual(result.data.parsed, {
@@ -65,10 +69,11 @@ describe("parseNamespaceOrTag", () => {
     });
     it("should give an error with an invalid namespace", () => {
         const reader = new StringReader("minecraft:fail:surplus");
-        const result = parseNamespaceOrTag(reader, {
-            ...blankproperties,
-            suggesting: false
-        });
+        const result = parseNamespaceOrTag(
+            reader,
+            { ...blankproperties, suggesting: false },
+            errorBuilder
+        );
         if (
             returnAssert(result, {
                 errors: [
@@ -91,13 +96,13 @@ describe("parseNamespaceOrTag", () => {
                 ...blankproperties,
                 suggesting: false
             },
-            undefined
+            errorBuilder
         );
         if (
             returnAssert(result, {
                 errors: [
                     {
-                        code: "argument.tags.notallowed",
+                        code: "test",
                         range: { start: 1, end: 14 }
                     }
                 ],

--- a/src/test/misc_functions/parsing/nmsp_tag.test.ts
+++ b/src/test/misc_functions/parsing/nmsp_tag.test.ts
@@ -103,7 +103,7 @@ describe("parseNamespaceOrTag", () => {
                 errors: [
                     {
                         code: "test",
-                        range: { start: 1, end: 14 }
+                        range: { start: 0, end: 14 }
                     }
                 ],
                 succeeds: false

--- a/src/test/parsers/brigadier/string.test.ts
+++ b/src/test/parsers/brigadier/string.test.ts
@@ -21,7 +21,7 @@ describe("String Argument Parser", () => {
             });
             it("should read a quoted string section", () => {
                 const result = tester('"quote test" :"-)(*', succeeds);
-                assert.strictEqual(result[1].cursor, 11);
+                assert.strictEqual(result[1].cursor, 12);
             });
         });
         describe("Word String", () => {

--- a/src/test/parsers/minecraft/block.test.ts
+++ b/src/test/parsers/minecraft/block.test.ts
@@ -1,8 +1,8 @@
 import { ok } from "assert";
-import { parseBlockArgument } from "../../../../parsers/minecraft/block/shared";
-import { CommmandData, Parser } from "../../../../types";
-import { testParser } from "../../../assertions";
-import { blankproperties, succeeds } from "../../../blanks";
+import { parseBlockArgument } from "../../../parsers/minecraft/block/shared";
+import { CommmandData, Parser } from "../../../types";
+import { testParser } from "../../assertions";
+import { blankproperties, succeeds } from "../../blanks";
 
 const parser: Parser = {
     parse: (reader, info) =>

--- a/src/test/parsers/minecraft/block/shared.test.ts
+++ b/src/test/parsers/minecraft/block/shared.test.ts
@@ -1,0 +1,331 @@
+import { ok } from "assert";
+import { parseBlockArgument } from "../../../../parsers/minecraft/block/shared";
+import { CommmandData, Parser } from "../../../../types";
+import { testParser } from "../../../assertions";
+import { blankproperties, succeeds } from "../../../blanks";
+
+const parser: Parser = {
+    parse: (reader, info) =>
+        parseBlockArgument(reader, info, !!info.node_properties.tags)
+};
+
+const blockArgumentTester = testParser(parser);
+
+const data: CommmandData = {
+    globalData: {
+        blocks: {
+            "langserver:multi": {
+                otherprop: ["lang", "propvalue"],
+                prop1: ["value", "value2", "other"]
+            },
+            "langserver:noprops": {},
+            "langserver:props": {
+                prop: ["value", "value2", "other"]
+            },
+            "minecraft:lang": {},
+            "minecraft:test": { state: ["react", "redux"] }
+        },
+        resources: {
+            block_tags: [
+                { namespace: "test", path: "empty" },
+                {
+                    data: { values: [] },
+                    namespace: "test",
+                    path: "empty_values"
+                },
+                {
+                    data: {
+                        values: ["langserver:multi", "langserver:props", "test"]
+                    },
+                    namespace: "test",
+                    path: "plain"
+                },
+                { namespace: "minecraft", path: "empty" },
+                {
+                    data: { values: ["minecraft:test", "langserver:noprops"] },
+                    namespace: "minecraft",
+                    path: "plain"
+                },
+                {
+                    data: { values: ["langserver:props", "#plain"] },
+                    namespace: "test",
+                    path: "othertags"
+                },
+                {
+                    data: {
+                        values: ["langserver:props", "#test:plain"]
+                    },
+                    namespace: "test",
+                    path: "duplicated_block"
+                },
+                {
+                    data: {
+                        values: [
+                            "langserver:multi",
+                            "unknown",
+                            "langserver:notablock"
+                        ]
+                    },
+                    namespace: "test",
+                    path: "invalid_block"
+                }
+            ]
+        }
+    },
+    localData: {
+        packs: {
+            0: {
+                data: {
+                    block_tags: [
+                        {
+                            data: { values: ["#plain", "langserver:multi"] },
+                            namespace: "localdata",
+                            path: "token"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+} as any;
+
+describe("sharedBlockParser", () => {
+    describe("Tags allowed", () => {
+        const test = blockArgumentTester({
+            ...blankproperties,
+            data,
+            node_properties: { tags: true }
+        });
+        plainBlockTests(test);
+        it("should parse a plain tag", () => {
+            test("#test:empty", {
+                start: 1,
+                succeeds: true,
+                suggestions: ["test:empty", "test:empty_values"]
+            });
+        });
+        it("should give an error for an unknown tag", () => {
+            test("#test:unknown", {
+                errors: [
+                    {
+                        code: "arguments.block.tag.unknown",
+                        range: { start: 0, end: 13 }
+                    }
+                ],
+                succeeds: true
+            });
+        });
+        it("should suggest the correct properties", () => {
+            const [result] = test("#test:plain[", {
+                errors: [
+                    {
+                        code: "argument.block.property.unclosed",
+                        range: { start: 11, end: 12 }
+                    }
+                ],
+                numActions: 1,
+                start: 12,
+                succeeds: false,
+                suggestions: ["otherprop", "prop1", "prop", "state"]
+            });
+            ok(result.actions.every(a => a.type === "hover"));
+        });
+    });
+    describe("Tags not allowed", () => {
+        const test = blockArgumentTester({
+            ...blankproperties,
+            data,
+            node_properties: { tags: false }
+        });
+        plainBlockTests(test);
+        it("should give an error when tags are used", () => {
+            test("#minecraft:anything", {
+                errors: [
+                    {
+                        code: "argument.block.tag.disallowed",
+                        range: { start: 0, end: 19 }
+                    }
+                ],
+                succeeds: false
+            });
+        });
+        // N.B properties are never actually parsed in this case
+        it("should not give further errors when properties are used", () => {
+            test("#minecraft:anything[anyprop=value]", {
+                errors: [
+                    {
+                        code: "argument.block.tag.disallowed",
+                        range: { start: 0, end: 19 }
+                    }
+                ],
+                succeeds: false
+            });
+        });
+    });
+});
+
+function plainBlockTests(test: ReturnType<typeof blockArgumentTester>): void {
+    it("should allow a plain block", () => {
+        test("langserver:noprops", {
+            succeeds: true,
+            suggestions: ["langserver:noprops"]
+        });
+    });
+    it("should successfully parse an empty properties", () => {
+        test("langserver:noprops[]", {
+            succeeds: true
+        });
+    });
+    it("should successfully parse an empty properties with whitespace", () => {
+        test("langserver:noprops[  ]", { succeeds: true });
+    });
+    it("should successfully parse a single block's properties", () => {
+        test("langserver:props[prop=value]", { succeeds: true });
+    });
+    it("should successfully parse a single block's properties with quotes", () => {
+        test('langserver:props["prop"="value"]', {
+            succeeds: true
+        });
+    });
+    it("should give the correct error for an unknown property", () => {
+        test("langserver:props[unknown=value]", {
+            errors: [
+                {
+                    code: "argument.block.property.unknown",
+                    range: { start: 17, end: 24 }
+                }
+            ],
+            succeeds: true
+        });
+    });
+    it("should give an error for an incorrect property value", () => {
+        test("langserver:props[prop=unknown]", {
+            errors: [
+                {
+                    code: "argument.block.property.invalid",
+                    range: { start: 22, end: 29 }
+                }
+            ],
+            succeeds: true
+        });
+    });
+    it("should allow multiple properties", () => {
+        test("langserver:multi[otherprop=propvalue,prop1=other]", succeeds);
+    });
+    it("should give an error for duplicate properties", () => {
+        test("langserver:multi[otherprop=propvalue,otherprop=lang]", {
+            errors: [
+                {
+                    code: "argument.block.property.duplicate",
+                    range: { start: 37, end: 46 }
+                }
+            ],
+            succeeds: true
+        });
+    });
+    it("should give an error when the properties are not closed", () => {
+        test("langserver:multi[otherprop=lang", {
+            errors: [
+                {
+                    code: "argument.block.property.unclosed",
+                    range: { start: 16, end: 31 }
+                }
+            ],
+            succeeds: false,
+            suggestions: [{ start: 27, text: "lang" }]
+        });
+    });
+    it("should give the correct block suggestions", () => {
+        test("langserver:", {
+            errors: [
+                {
+                    code: "argument.block.id.invalid",
+                    range: { start: 0, end: 11 }
+                }
+            ],
+            succeeds: true, // Even though is invalid, it could be valid if there was a block "langserver:""
+            suggestions: [
+                "langserver:multi",
+                "langserver:noprops",
+                "langserver:props"
+            ]
+        });
+    });
+    it("should suggest the blocks with both the namespace and in the minecraft namespace", () => {
+        test("lang", {
+            succeeds: true,
+            suggestions: [
+                "langserver:multi",
+                "langserver:noprops",
+                "langserver:props",
+                "minecraft:lang"
+            ]
+        });
+    });
+    it("should suggest the correct property names", () => {
+        test("langserver:multi[", {
+            errors: [
+                {
+                    code: "argument.block.property.unclosed",
+                    range: { start: 16, end: 17 }
+                }
+            ],
+            start: 17,
+            succeeds: false,
+            suggestions: ["prop1", "otherprop"]
+        });
+    });
+    it("should give an error when there is no value given", () => {
+        test("langserver:props[prop", {
+            errors: [
+                {
+                    code: "argument.block.property.novalue",
+                    range: { start: 17, end: 21 }
+                }
+            ],
+            succeeds: false,
+            suggestions: [{ start: 17, text: "prop" }]
+        });
+    });
+    it("should give an error when there is no value given", () => {
+        test('langserver:props["prop"extra', {
+            errors: [
+                {
+                    code: "argument.block.property.novalue",
+                    range: { start: 17, end: 23 }
+                }
+            ],
+            succeeds: false
+        });
+    });
+    it("should give the correct suggestions for an empty property value", () => {
+        test("langserver:props[prop=", {
+            errors: [
+                {
+                    code: "argument.block.property.unclosed",
+                    range: { start: 16, end: 22 }
+                }
+            ],
+            start: 22,
+            succeeds: false,
+            suggestions: ["value", "value2", "other"]
+        });
+    });
+    it("should give the correct suggestions for a started property value", () => {
+        test("langserver:props[prop=val", {
+            errors: [
+                {
+                    code: "argument.block.property.unclosed",
+                    range: { start: 16, end: 25 }
+                },
+                {
+                    code: "argument.block.property.invalid",
+                    range: { start: 22, end: 25 }
+                }
+            ],
+            start: 22,
+            succeeds: false,
+            suggestions: ["value", "value2"]
+        });
+    });
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import { DataInterval, Interval, IntervalTree } from "node-interval-tree";
 import { CompletionItemKind } from "vscode-languageserver";
 import { BlankCommandError, CommandError } from "./brigadier_components/errors";
 import { StringReader } from "./brigadier_components/string_reader";
-import { CommandNodePath, GlobalData, PacksInfo } from "./data/types";
+import { CommandNodePath, GlobalData, LocalData } from "./data/types";
 import { PackLocationSegments } from "./misc_functions";
 
 //#region Document
@@ -50,7 +50,7 @@ export interface CommmandData {
     /**
      * Data from datapacks
      */
-    localData?: PacksInfo;
+    localData?: LocalData;
 }
 
 export interface Suggestion {

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,7 +116,8 @@ interface SubActionBase<U extends string, T> extends DataInterval<T> {
 
 export type SubAction =
     | SubActionBase<"hover", string>
-    | SubActionBase<"format", string>;
+    | SubActionBase<"format", string>
+    | SubActionBase<"source", string>;
 // | SubActionBase<"rename", RenameRequest>;
 //#endregion
 export type Success = true;

--- a/test_data/test_world/datapacks/ExampleDatapack/data/minecraft/tags/functions/tick.json
+++ b/test_data/test_world/datapacks/ExampleDatapack/data/minecraft/tags/functions/tick.json
@@ -1,3 +1,3 @@
 {
-    "values": ["value1", "value2"]
+    "values": ["test_namespace:function"]
 }


### PR DESCRIPTION
Additionally changes how `readJson` is handled to allow a more robust tag parser and better errors.

Is missing nbt handling but that should probably be included in #8 after this has merged