### PR TITLE
Remove last uses of require

### DIFF
--- a/src/declaration.d.ts
+++ b/src/declaration.d.ts
@@ -86,8 +86,8 @@ interface McFunctionSettings extends LocalMcFunctionSettings {
      * Custom parsers to be used.
      * Note that external users of the server should not support this setting
      */
-    parsers: {
-        [name: string]: string;
+    parsers?: {
+        [name: string]: import("./types").Parser;
     };
 }
 

--- a/src/parsers/brigadier/bool.ts
+++ b/src/parsers/brigadier/bool.ts
@@ -2,9 +2,7 @@ import { CompletionItemKind } from "vscode-languageserver/lib/main";
 import { prepareForParser } from "../../misc-functions";
 import { Parser } from "../../types";
 
-const parser: Parser = {
+export const boolParser: Parser = {
     kind: CompletionItemKind.Keyword,
     parse: (reader, props) => prepareForParser(reader.readBoolean(), props)
 };
-
-export = parser;

--- a/src/parsers/brigadier/float.ts
+++ b/src/parsers/brigadier/float.ts
@@ -16,7 +16,7 @@ const FLOATEXCEPTIONS = {
     )
 };
 
-const parser: Parser = {
+export const floatParser: Parser = {
     parse: (reader, properties) => {
         const helper = new ReturnHelper(properties);
         const start = reader.cursor;
@@ -58,5 +58,3 @@ const parser: Parser = {
         return helper.succeed();
     }
 };
-
-export = parser;

--- a/src/parsers/brigadier/index.ts
+++ b/src/parsers/brigadier/index.ts
@@ -1,0 +1,4 @@
+export * from "./bool";
+export * from "./string";
+export * from "./integer";
+export * from "./float";

--- a/src/parsers/brigadier/integer.ts
+++ b/src/parsers/brigadier/integer.ts
@@ -16,7 +16,7 @@ const INTEGEREXCEPTIONS = {
     )
 };
 
-const parser: Parser = {
+export const intParser: Parser = {
     parse: (reader, properties) => {
         const helper = new ReturnHelper(properties);
         const start = reader.cursor;
@@ -58,5 +58,3 @@ const parser: Parser = {
         return helper.succeed();
     }
 };
-
-export = parser;

--- a/src/parsers/brigadier/string.ts
+++ b/src/parsers/brigadier/string.ts
@@ -1,7 +1,7 @@
 import { ReturnHelper } from "../../misc-functions";
 import { Parser } from "../../types";
 
-const parser: Parser = {
+export const stringParser: Parser = {
     parse: (reader, properties) => {
         const helper = new ReturnHelper(properties);
         switch (properties.node_properties.type) {
@@ -20,5 +20,3 @@ const parser: Parser = {
         }
     }
 };
-
-export = parser;

--- a/src/parsers/get-parser.ts
+++ b/src/parsers/get-parser.ts
@@ -1,23 +1,23 @@
-/* tslint:disable:no-require-imports */
-
 import { CommandNode } from "../data/types";
 import { Parser } from "../types";
 
-import * as literalParser from "./literal";
+import * as brigadierParsers from "./brigadier";
+import { literalParser } from "./literal";
 import * as blockParsers from "./minecraft/block";
 import * as coordParsers from "./minecraft/coordinates";
 import * as itemParsers from "./minecraft/item";
 import * as listParsers from "./minecraft/lists";
+import { messageParser } from "./minecraft/message";
 
 /**
  * Incomplete:
  * https://github.com/Levertion/mcfunction-langserver/projects/1
  */
 const implementedParsers: { [id: string]: Parser } = {
-    "brigadier:bool": require("./brigadier/bool"),
-    "brigadier:float": require("./brigadier/float"),
-    "brigadier:integer": require("./brigadier/integer"),
-    "brigadier:string": require("./brigadier/string"),
+    "brigadier:bool": brigadierParsers.boolParser,
+    "brigadier:float": brigadierParsers.floatParser,
+    "brigadier:integer": brigadierParsers.intParser,
+    "brigadier:string": brigadierParsers.stringParser,
     "minecraft:block_pos": coordParsers.blockPos,
     "minecraft:block_predicate": blockParsers.predicateParser,
     "minecraft:block_state": blockParsers.stateParser,
@@ -27,7 +27,7 @@ const implementedParsers: { [id: string]: Parser } = {
     "minecraft:item_predicate": itemParsers.predicate,
     "minecraft:item_slot": listParsers.itemSlotParser,
     "minecraft:item_stack": itemParsers.stack,
-    "minecraft:message": require("./minecraft/message"),
+    "minecraft:message": messageParser,
     "minecraft:mob_effect": listParsers.mobEffectParser,
     "minecraft:operation": listParsers.operationParser,
     "minecraft:particle": listParsers.particleParser,
@@ -53,12 +53,12 @@ export function getParser(node: CommandNode): Parser | undefined {
 
 function getArgParser(id: string): Parser | undefined {
     if (
-        !!global.mcLangSettings && // Protection for tests when settings are undefined
+        !!global.mcLangSettings &&
         !!global.mcLangSettings.parsers &&
         global.mcLangSettings.parsers.hasOwnProperty(id)
     ) {
         try {
-            return require(global.mcLangSettings.parsers[id]);
+            return global.mcLangSettings.parsers[id];
         } catch (_) {
             mcLangLog(
                 `${global.mcLangSettings.parsers[id]} could not be loaded`

--- a/src/parsers/literal.ts
+++ b/src/parsers/literal.ts
@@ -2,7 +2,7 @@ import { CompletionItemKind } from "vscode-languageserver/lib/main";
 import { ReturnHelper } from "../misc-functions";
 import { Parser } from "../types";
 
-const parser: Parser = {
+export const literalParser: Parser = {
     kind: CompletionItemKind.Method,
     parse: (reader, properties) => {
         const helper = new ReturnHelper(properties);
@@ -26,5 +26,3 @@ const parser: Parser = {
         return helper.fail();
     }
 };
-
-export = parser;

--- a/src/parsers/minecraft/message.ts
+++ b/src/parsers/minecraft/message.ts
@@ -2,11 +2,9 @@ import { StringReader } from "../../brigadier/string-reader";
 import { ReturnHelper } from "../../misc-functions";
 import { Parser } from "../../types";
 
-const parser: Parser = {
+export const messageParser: Parser = {
     parse: (reader: StringReader) => {
         reader.cursor = reader.getTotalLength();
         return new ReturnHelper().succeed();
     }
 };
-
-export = parser;

--- a/src/test/completions.test.ts
+++ b/src/test/completions.test.ts
@@ -1,5 +1,4 @@
 import * as assert from "assert";
-import { join } from "path";
 import {
     CompletionItemKind,
     CompletionList
@@ -7,6 +6,7 @@ import {
 import { computeCompletions } from "../completions";
 import { DataManager } from "../data/manager";
 import { pack_segments } from "./blanks";
+import { dummyParser } from "./parsers/tests/dummy1";
 
 const data = DataManager.newWithData(
     {
@@ -40,12 +40,7 @@ describe("ComputeCompletions()", () => {
     before(() => {
         global.mcLangSettings = {
             parsers: {
-                "langserver:dummy1": join(
-                    __dirname,
-                    "parsers",
-                    "tests",
-                    "dummy1"
-                )
+                "langserver:dummy1": dummyParser
             }
         } as any;
     });

--- a/src/test/parse.test.ts
+++ b/src/test/parse.test.ts
@@ -1,9 +1,9 @@
 import * as assert from "assert";
-import { join } from "path";
 import { GlobalData } from "../data/types";
 import { parseCommand } from "../parse";
 import { ParseNode, StoredParseResult } from "../types";
 import { assertErrors, ErrorInfo } from "./assertions";
+import { dummyParser } from "./parsers/tests/dummy1";
 
 const fakeGlobal: GlobalData = {} as any;
 
@@ -36,12 +36,7 @@ describe("parseCommand()", () => {
     before(() => {
         global.mcLangSettings = {
             parsers: {
-                "langserver:dummy1": join(
-                    __dirname,
-                    "parsers",
-                    "tests",
-                    "dummy1"
-                )
+                "langserver:dummy1": dummyParser
             }
         } as any;
     });

--- a/src/test/parsers/brigadier/bool.test.ts
+++ b/src/test/parsers/brigadier/bool.test.ts
@@ -1,7 +1,7 @@
-import * as boolArgumentParser from "../../../parsers/brigadier/bool";
+import { boolParser } from "../../../parsers/brigadier";
 import { testParser } from "../../assertions";
 
-const boolTester = testParser(boolArgumentParser);
+const boolTester = testParser(boolParser);
 const testWithBasicProps = boolTester();
 
 describe("Boolean Argument Parser", () => {

--- a/src/test/parsers/brigadier/float.test.ts
+++ b/src/test/parsers/brigadier/float.test.ts
@@ -1,9 +1,9 @@
 import * as assert from "assert";
-import * as floatArgumentParser from "../../../parsers/brigadier/float";
+import { floatParser } from "../../../parsers/brigadier";
 import { testParser } from "../../assertions";
 import { blankproperties } from "../../blanks";
 
-const floatTester = testParser(floatArgumentParser);
+const floatTester = testParser(floatParser);
 describe("Float Argument Parser", () => {
     function validFloatTests(
         s: string,

--- a/src/test/parsers/brigadier/integer.test.ts
+++ b/src/test/parsers/brigadier/integer.test.ts
@@ -1,8 +1,8 @@
 import * as assert from "assert";
-import * as integerArgumentParser from "../../../parsers/brigadier/integer";
+import { intParser } from "../../../parsers/brigadier";
 import { testParser } from "../../assertions";
 
-const integerTest = testParser(integerArgumentParser);
+const integerTest = testParser(intParser);
 
 describe("Integer Argument Parser", () => {
     function validIntTests(

--- a/src/test/parsers/brigadier/string.test.ts
+++ b/src/test/parsers/brigadier/string.test.ts
@@ -1,9 +1,9 @@
 import * as assert from "assert";
-import * as stringArgumentParser from "../../../parsers/brigadier/string";
+import { stringParser } from "../../../parsers/brigadier";
 import { testParser } from "../../assertions";
 import { succeeds } from "../../blanks";
 
-const stringTest = testParser(stringArgumentParser);
+const stringTest = testParser(stringParser);
 
 describe("String Argument Parser", () => {
     describe("parse()", () => {

--- a/src/test/parsers/get-parser.test.ts
+++ b/src/test/parsers/get-parser.test.ts
@@ -1,26 +1,26 @@
 import * as assert from "assert";
-import * as path from "path";
-import * as stringParser from "../../parsers/brigadier/string";
+import { stringParser } from "../../parsers/brigadier";
 import { getParser } from "../../parsers/get-parser";
-import * as literal from "../../parsers/literal";
-import * as dummy1 from "./tests/dummy1";
+
+import { literalParser } from "../../parsers/literal";
+import { dummyParser } from "./tests/dummy1";
 
 describe("getParser()", () => {
     it("should give the literal parser for a literal node", () => {
         const parser = getParser({ type: "literal" });
-        assert.strictEqual(parser, literal);
+        assert.strictEqual(parser, literalParser);
     });
     it("should give the correct parser for a custom parser", () => {
         global.mcLangSettings = ({
             parsers: {
-                "langserver:dummy1": path.join(__dirname, "tests", "dummy1")
+                "langserver:dummy1": dummyParser
             }
         } as any) as McFunctionSettings;
         const parser = getParser({
             parser: "langserver:dummy1",
             type: "argument"
         });
-        assert.strictEqual(parser, dummy1);
+        assert.strictEqual(parser, dummyParser);
     });
     it("should give the correct parser for a builtin parser", () => {
         const parser = getParser({

--- a/src/test/parsers/literal.test.ts
+++ b/src/test/parsers/literal.test.ts
@@ -1,42 +1,41 @@
 import * as assert from "assert";
-import * as literalArgumentParser from "../../parsers/literal";
+
+import { literalParser } from "../../parsers/literal";
 import { testParser } from "../assertions";
 
-const literalTest = testParser(literalArgumentParser)({ path: ["test"] });
+const literalTest = testParser(literalParser)({ path: ["test"] });
 
-describe("literalArgumentParser", () => {
-    describe("parse()", () => {
-        describe("literal correct", () => {
-            it("should succeed, suggesting the string", () => {
-                const result = literalTest("test", {
-                    succeeds: true,
-                    suggestions: ["test"]
-                });
-                assert.strictEqual(result[1].cursor, 4);
+describe("Literal Argument Parser", () => {
+    describe("literal correct", () => {
+        it("should succeed, suggesting the string", () => {
+            const result = literalTest("test", {
+                succeeds: true,
+                suggestions: ["test"]
             });
-            it("should set the cursor to after the string when it doesn't reach the end", () => {
-                const result = literalTest("test ", {
-                    succeeds: true
-                });
-                assert.strictEqual(result[1].cursor, 4);
+            assert.strictEqual(result[1].cursor, 4);
+        });
+        it("should set the cursor to after the string when it doesn't reach the end", () => {
+            const result = literalTest("test ", {
+                succeeds: true
+            });
+            assert.strictEqual(result[1].cursor, 4);
+        });
+    });
+    describe("literal not matching", () => {
+        it("should fail when the first character doesn't match", () => {
+            literalTest("fail ", {
+                succeeds: false
             });
         });
-        describe("literal not matching", () => {
-            it("should fail when the first character doesn't match", () => {
-                literalTest("fail ", {
-                    succeeds: false
-                });
+        it("should fail when the last character doesn't match", () => {
+            literalTest("tesnot", {
+                succeeds: false
             });
-            it("should fail when the last character doesn't match", () => {
-                literalTest("tesnot", {
-                    succeeds: false
-                });
-            });
-            it("should suggest the string if the start is given", () => {
-                literalTest("tes", {
-                    succeeds: false,
-                    suggestions: ["test"]
-                });
+        });
+        it("should suggest the string if the start is given", () => {
+            literalTest("tes", {
+                succeeds: false,
+                suggestions: ["test"]
             });
         });
     });

--- a/src/test/parsers/minecraft/message.test.ts
+++ b/src/test/parsers/minecraft/message.test.ts
@@ -1,13 +1,13 @@
 import * as assert from "assert";
 import { StringReader } from "../../../brigadier/string-reader";
-import * as parser from "../../../parsers/minecraft/message";
+import { messageParser } from "../../../parsers/minecraft/message";
 import { ParserInfo } from "../../../types";
 
 describe("Message parser", () => {
     it("should set the cursor to the correct position", () => {
         const reader = new StringReader("say this is a super fun string");
         reader.cursor = 4;
-        parser.parse(reader, {} as ParserInfo);
+        messageParser.parse(reader, {} as ParserInfo);
         assert.strictEqual(reader.cursor, 30);
     });
 });

--- a/src/test/parsers/tests/dummy1.test.ts
+++ b/src/test/parsers/tests/dummy1.test.ts
@@ -1,8 +1,8 @@
 import * as assert from "assert";
 import { testParser } from "../../assertions";
-import * as dummyparser from "./dummy1";
+import { dummyParser } from "./dummy1";
 
-const dummyParserTester = testParser(dummyparser);
+const dummyParserTester = testParser(dummyParser);
 
 describe("dummyParser1", () => {
     describe("parse", () => {

--- a/src/test/parsers/tests/dummy1.ts
+++ b/src/test/parsers/tests/dummy1.ts
@@ -5,7 +5,7 @@ import { Parser } from "../../../types";
  * Used for testing.
  * Do not attempt to use an actual command tree using this.
  */
-const parser: Parser = {
+export const dummyParser: Parser = {
     parse: (reader, props) => {
         const helper = new ReturnHelper(props);
         const num: number = (props.node_properties.number as number) || 3;
@@ -22,5 +22,3 @@ const parser: Parser = {
         }
     }
 };
-
-export = parser;


### PR DESCRIPTION
This fixes the remaining uses of node's `require` api (outside of those generated by Typescript for import statements)