### PR TITLE
Fixed itemCriteria and fixed whitespace error on data modify

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6702,6 +6702,8 @@ function parsePath(reader) {
 
         return helper.fail();
       }
+    } else if (reader.peek() == " ") {
+      return helper.succeed(result);
     } else {
       return helper.fail(exceptions.BAD_CHAR.create(reader.cursor - 1, reader.cursor, reader.peek()));
     }
@@ -7131,7 +7133,7 @@ exports.criteriaParser = {
       reader.cursor = postStart;
 
       if (misc_functions_1.namespacesEqual(data.literal, choice)) {
-        const result = misc_functions_1.parseNamespaceOption(reader, misc_functions_1.stringArrayToNamespaces([...info.data.globalData.registries["minecraft:entity_type"]]), vscode_languageserver_1.CompletionItemKind.Reference, ".");
+        const result = misc_functions_1.parseNamespaceOption(reader, misc_functions_1.stringArrayToNamespaces([...info.data.globalData.registries["minecraft:item"]]), vscode_languageserver_1.CompletionItemKind.Reference, ".");
 
         if (helper.merge(result)) {
           return helper.succeed();

--- a/dist/index.js
+++ b/dist/index.js
@@ -6702,7 +6702,7 @@ function parsePath(reader) {
 
         return helper.fail();
       }
-    } else if (reader.peek() == " ") {
+    } else if (reader.peek() === " ") {
       return helper.succeed(result);
     } else {
       return helper.fail(exceptions.BAD_CHAR.create(reader.cursor - 1, reader.cursor, reader.peek()));

--- a/src/parsers/minecraft/nbt-path.ts
+++ b/src/parsers/minecraft/nbt-path.ts
@@ -683,6 +683,8 @@ function parsePath(reader: StringReader): ReturnedInfo<PathParseResult> {
                 }
                 return helper.fail();
             }
+        } else if (reader.peek() == " ") {
+            return helper.succeed(result);
         } else {
             return helper.fail(
                 exceptions.BAD_CHAR.create(

--- a/src/parsers/minecraft/nbt-path.ts
+++ b/src/parsers/minecraft/nbt-path.ts
@@ -683,7 +683,7 @@ function parsePath(reader: StringReader): ReturnedInfo<PathParseResult> {
                 }
                 return helper.fail();
             }
-        } else if (reader.peek() == " ") {
+        } else if (reader.peek() === " ") {
             return helper.succeed(result);
         } else {
             return helper.fail(

--- a/src/parsers/minecraft/scoreboard.ts
+++ b/src/parsers/minecraft/scoreboard.ts
@@ -285,9 +285,7 @@ export const criteriaParser: Parser = {
                 const result = parseNamespaceOption(
                     reader,
                     stringArrayToNamespaces([
-                        ...info.data.globalData.registries[
-                            "minecraft:entity_type"
-                        ]
+                        ...info.data.globalData.registries["minecraft:item"]
                     ]),
                     CompletionItemKind.Reference,
                     "."


### PR DESCRIPTION
Fixed itemCriteria returning entities instead of items. Fixed data modiy so that it does not return an error when there is whitespace after the nbt path.

Edit by @Levertion: fixes #134 
fixes #133.